### PR TITLE
Continuous zoom

### DIFF
--- a/_command_tester.py
+++ b/_command_tester.py
@@ -9,6 +9,10 @@ command_service = CommandService()
 # Modify the command_type and command_value as needed
 #######-####### ZOOM #######-#######
 # command_service.add_input_command(command_type=CommandType.ZOOM, command_value="1.0")
+command_service.add_input_command(command_type=CommandType.ZOOM, command_value="in")
+# command_service.add_input_command(command_type=CommandType.ZOOM, command_value="out")
+# time.sleep(2)
+# command_service.add_input_command(command_type=CommandType.ZOOM, command_value="stop")
 
 #######-####### PHOTO #######-#######
 # command_service.add_input_command(command_type=CommandType.TAKE_PHOTO)
@@ -19,7 +23,7 @@ command_service = CommandService()
 # )
 
 #######-####### GCS #######-#######
-command_service.add_input_command(command_type=CommandType.START_GCS_STREAM)
+# command_service.add_input_command(command_type=CommandType.START_GCS_STREAM)
 # command_service.add_input_command(command_type=CommandType.STOP_GCS_STREAM)
 
 #######-####### RECORD #######-#######

--- a/_command_tester.py
+++ b/_command_tester.py
@@ -9,8 +9,8 @@ command_service = CommandService()
 # Modify the command_type and command_value as needed
 #######-####### ZOOM #######-#######
 # command_service.add_input_command(command_type=CommandType.ZOOM, command_value="1.0")
-command_service.add_input_command(command_type=CommandType.ZOOM, command_value="in")
-# command_service.add_input_command(command_type=CommandType.ZOOM, command_value="out")
+# command_service.add_input_command(command_type=CommandType.ZOOM, command_value="in")
+command_service.add_input_command(command_type=CommandType.ZOOM, command_value="out")
 # time.sleep(2)
 # command_service.add_input_command(command_type=CommandType.ZOOM, command_value="stop")
 

--- a/constants.py
+++ b/constants.py
@@ -9,6 +9,7 @@ STREAMING_FRAMESIZE: Final = "1280x720"  # 720p
 STILL_FRAMESIZE: Final = "3840x2160"  # 4K
 INPUT_FIFO_PATH: Final = "/tmp/pistreamer"
 OUTPUT_FIFO_PATH: Final = "/tmp/pistreamer_output"
+ZOOM_RATE: Final = 1.65  # zoom rate per second
 
 
 class CommandType(Enum):
@@ -28,8 +29,7 @@ class CommandType(Enum):
     STABILIZE = "stabilize"
 
 
-class CommandStatus(Enum):
-    PENDING = "pending"
-    RUNNING = "running"
-    COMPLETED = "completed"
-    FAILED = "failed"
+class ZoomStatus(Enum):
+    STOP = "stop"
+    IN = "in"
+    OUT = "out"

--- a/pistreamer_v2.py
+++ b/pistreamer_v2.py
@@ -20,6 +20,7 @@ from constants import (
     FRAMERATE,
     STREAMING_FRAMESIZE,
     STILL_FRAMESIZE,
+    ZoomStatus,
 )
 from utils import get_timestamp
 from validator import Validator
@@ -313,6 +314,8 @@ class PiStreamer2:
         # Init frame
         fps = []
 
+        self.start_gcs_stream()
+
         # Main loop
         try:
             i = 0
@@ -340,6 +343,12 @@ class PiStreamer2:
                     if self.prev_gray is None:
                         self.prev_gray = cv2.cvtColor(frame, cv2.COLOR_RGB2GRAY)
                     frame = self._stabilize(frame)
+
+                if (
+                    self.command_controller
+                    and self.command_controller.zoom_status != ZoomStatus.STOP.value
+                ):
+                    self.command_controller.do_continuous_zoom()
 
                 # Convert the frame back to YUV format before sending to FFmpeg
                 frame_8bit = cv2.convertScaleAbs(frame)


### PR DESCRIPTION
* The following commands are now supported to control continuous zoom and and out up to the defined limits.
  * `ZOOM IN`
  * `ZOOM OUT`
  * `ZOOM STOP`
* If max or min zoom is reached before a stop command is issued, then the app automatically stops.
* Zoom speed is defined by `ZOOM_RATE` which is currently 1.65x per second.
* GCS streaming will now start by default as well.

https://github.com/user-attachments/assets/b25efb6f-df08-4d3e-bd32-6f5dfbc94505

