### PR TITLE
Fix `gcs_ip` and `gcs_port` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ sudo apt install -y python3-numpy
 For normal (non-daemon) functionality run the script as below:
 
 ```
-python pistreamer_v2.py --gcs_ip={IP Address} --gcs_port={Port}
+python pistreamer_v2.py --gcs_ip={IP Address} --gcs_port={Port} --config_file="./477_Pi4.json"
 ```
 Once the app is running you can send a variety of commands (from a different session) via a FIFO by executing `_command_tester.py`.
 
@@ -43,14 +43,12 @@ command_service.add_input_command(command_type=CommandType.RECORD.value) #start 
 command_service.add_input_command(command_type=CommandType.STOP_RECORDING) #stop recording to mp4
 command_service.add_input_command(command_type=CommandType.TAKE_PHOTO) #take single frame photo at 4K resolution.
 command_service.add_input_command(command_type=CommandType.START_GCS_STREAM) #start the GCS feed
-command_service.add_input_command(command_type=CommandType.STABILIZE, command_value="start") #start stabilization at current framerate
-command_service.add_input_command(command_type=CommandType.STABILIZE, command_value="stop") #stop stabilization at current framerate
 ```
 
 ## Daemon operation
 To run the streamer and all ffmpeg processes in the background run the following:
 ```
-python pistreamer_v2.py &
+python pistreamer_v2.py
 ```
 
 ### To kill the dameon
@@ -64,7 +62,8 @@ sudo kill -9 {PROCESS_ID_FOUND_ABOVE}
 ```
 
 ## Stabilization
-Pass the flag `--stabilization` to the command line to achieve software image stabilization through opencv. Due to the computational overhead of stabilization, a significant FPS penalty is incurred at all resolutions. See the spec table below to evaluate the best options.
+Pass the flag `--stabilization` to the command line to achieve software image stabilization through opencv. Due to the computation overhead of stabilization,
+resolution is limited to `640x360` in order to maintain a natural FPS rate.
 
 ## Recording and Still Photos
 The command_type `record` will simultaneously record the RTP upsink video frames to a ts video file. The resolution is the same as the GCS receives. `take_photo` will capture a 4K still frame and save to the filesystem. One thing to note about the behavior of picamer2 is that only a single configuration (i.e. resolution) can be active on the camera at a time. In order to switch configuration, the camera but me stopped and restarted with the new configuration.
@@ -75,7 +74,7 @@ A camera tuning json file is expected. Starting points for these files for the I
 ## IMX477 EchoLITE SBX Performance Specs
 Below are bench tested results of the IMX477 functioning at various resolutions and capture modes. Captured video and photo files are saved to the RPi filesystem whilst the streaming destination a RTP feed to a configuration IP and port.
 
-### Resolutions & Aspect Ratios
+### Resolution & Aspect Ratio
 | Resolution | Aspect Ratio | Notes         |
 |------------|--------------|---------------|
 | 640x360    | 16:9         | 360p LD       |
@@ -110,18 +109,10 @@ In order to take a photo at higher resolution than streaming resolution, there i
 | Not 3840x2160        | 3840x2160        | 1.15 sec         |
 | Not 4056x3040        | 4056x3040        | 1.42 sec         |
 
+
 ### Streaming + Saved Video + Saved Photo (2M bitrate)
 To save a photo at the same resolution as streaming and recording video, there is no
 significant impact to fps or streaming delay. However, if capturing a photo at a
 higher resolution than streaming+video, the photo delay time above will apply and the
 mp4 file up to that point will be saved and a new mp4 file will resume after the photo
 has been captured.
-
-### Stabilized Streaming Only (2M bitrate)
-Software stabilization algorithms require significant overhead which lowers the max FPS available.
-If this mode is desired 480p is recommended as a fair balance between image quality, FPS, and lag.
-| Resolution | Avg. Frame Rate | Aspect Ratio | Notes                                                                  |
-|------------|-----------------|--------------|------------------------------------------------------------------------|
-| 640x360    | 28              | 16:9         | 360p LD - Higher FPS but may result in more frequency image cropping   |
-| 854x480    | 16              | 16:9         | 480p SD - Lower FPS but may contribute to a perceived smoother display |
-| 1280x720   | 7               | 16:9         | 720p HD - Lowest FPS which introduces perceived lag. Not recommended.  |

--- a/_command_tester.py
+++ b/_command_tester.py
@@ -9,13 +9,12 @@ command_service = CommandService()
 # Modify the command_type and command_value as needed=
 
 #######-####### BITRATE #######-#######
-command_service.add_input_command(
-    command_type=CommandType.BITRATE, command_value="2010"
-)
+# command_service.add_input_command(command_type=CommandType.BITRATE, command_value="2010")
 
 #######-####### ZOOM #######-#######
-# command_service.add_input_command(command_type=CommandType.ZOOM, command_value="1.0")
-# command_service.add_input_command(command_type=CommandType.ZOOM, command_value="in")
+# command_service.add_input_command(command_type=CommandType.ZOOM, command_value="1.05")
+# command_service.add_input_command(command_type=CommandType.ZOOM, command_value="10")
+command_service.add_input_command(command_type=CommandType.ZOOM, command_value="in")
 # command_service.add_input_command(command_type=CommandType.ZOOM, command_value="out")
 # time.sleep(2)
 # command_service.add_input_command(command_type=CommandType.ZOOM, command_value="stop")
@@ -29,6 +28,9 @@ command_service.add_input_command(
 # )
 
 #######-####### GCS #######-#######
+# command_service.add_input_command(command_type=CommandType.GCS_IP, command_value="192.168.1.124")
+# command_service.add_input_command(command_type=CommandType.GCS_PORT, command_value="5600")
+# command_service.add_input_command(command_type=CommandType.GCS_HOST, command_value="192.168.1.124:5600")
 # command_service.add_input_command(command_type=CommandType.START_GCS_STREAM)
 # command_service.add_input_command(command_type=CommandType.STOP_GCS_STREAM)
 
@@ -39,6 +41,6 @@ command_service.add_input_command(
 
 #######-####### STABILIZE #######-#######
 # command_service.add_input_command(command_type=CommandType.STABILIZE, command_value="start")
-command_service.add_input_command(
-    command_type=CommandType.STABILIZE, command_value="stop"
-)
+# command_service.add_input_command(
+#     command_type=CommandType.STABILIZE, command_value="stop"
+# )

--- a/constants.py
+++ b/constants.py
@@ -2,8 +2,8 @@ from typing import Final
 from enum import Enum
 
 FRAMERATE: Final = 30
-MIN_ZOOM: Final = 1.0
-MAX_ZOOM: Final = 8.0
+MIN_ZOOM: Final = 1.05
+MAX_ZOOM: Final = 16.0
 DEFAULT_CONFIG_PATH: Final = "477-Pi4.json"
 STREAMING_FRAMESIZE: Final = "1280x720"  # 720p
 STILL_FRAMESIZE: Final = "3840x2160"  # 4K
@@ -16,8 +16,11 @@ class CommandType(Enum):
     STOP = "stop"
     KILL = "kill"
     BITRATE = "bitrate"
-    PORT = "port"
-    IP_ADDRESS = "ip_address"
+    GCS_IP = "gcs_ip"
+    GCS_PORT = "gcs_port"
+    GCS_HOST = (
+        "gsc_host"  # use this if you want to change ip address and port simultaneously
+    )
     RECORD = "record"
     STOP_RECORDING = "stop_recording"
     START_GCS_STREAM = "start_gcs_stream"

--- a/ffmpeg_configs.py
+++ b/ffmpeg_configs.py
@@ -37,8 +37,8 @@ def get_ffmpeg_command_record(resolution: Tuple[int, ...], framerate: str) -> Li
 def get_ffmpeg_command_gcs(
     resolution: Tuple[int, ...],
     framerate: str,
-    destination_ip: str,
-    destination_port: str,
+    gcs_ip: str,
+    gcs_port: str,
     streaming_bitrate: str,
 ) -> List[str]:
     # Used for streaming video to GCS
@@ -67,15 +67,15 @@ def get_ffmpeg_command_gcs(
         "nobuffer",  # No buffer for RTP
         "-f",
         "rtp",  # Output format for RTP
-        f"rtp://{destination_ip}:{destination_port}",
+        f"rtp://{gcs_ip}:{gcs_port}",
     ]
 
 
 def get_ffmpeg_command_atak(
     resolution: Tuple[int, ...],
     framerate: str,
-    destination_ip: str,
-    destination_port: str,
+    atak_ip: str,
+    atak_port: str,
     streaming_bitrate: str,
 ) -> List[str]:
     # Used for streaming video to ATAK
@@ -104,5 +104,5 @@ def get_ffmpeg_command_atak(
         "nobuffer",  # No buffer for RTP
         "-f",
         "mpegts",  # Output format for MPEG-TS
-        f"udp://{destination_ip}:{destination_port}",
+        f"udp://{atak_ip}:{atak_port}",
     ]


### PR DESCRIPTION
* `gcs_ip` and `gcs_port`  command changes now work
* Optionally, `gcs_host` can change both at the same time.
* Add `--verbose` command option
* Lower the rate of calculating fps
* Change max zoom to 16x
* Change min zoom to 1.05x and set at the start of streaming to help smooth the offset into zooming. However, there is still some cosmetic imperfection in the initial zoom phase (but could be passable imo).