### PR TITLE
Fix continuous zoom stretching and add output fifo command for zoom level

### DIFF
--- a/_command_tester.py
+++ b/_command_tester.py
@@ -12,9 +12,9 @@ command_service = CommandService()
 # command_service.add_input_command(command_type=CommandType.BITRATE, command_value="2010")
 
 #######-####### ZOOM #######-#######
-# command_service.add_input_command(command_type=CommandType.ZOOM, command_value="1.05")
-# command_service.add_input_command(command_type=CommandType.ZOOM, command_value="10")
-command_service.add_input_command(command_type=CommandType.ZOOM, command_value="in")
+# command_service.add_input_command(command_type=CommandType.ZOOM, command_value="1.0")
+# command_service.add_input_command(command_type=CommandType.MAX_ZOOM, command_value="8.0")
+# command_service.add_input_command(command_type=CommandType.ZOOM, command_value="in")
 # command_service.add_input_command(command_type=CommandType.ZOOM, command_value="out")
 # time.sleep(2)
 # command_service.add_input_command(command_type=CommandType.ZOOM, command_value="stop")

--- a/command_controller.py
+++ b/command_controller.py
@@ -189,7 +189,7 @@ class CommandController:
         self.pi_streamer.picam2.set_controls({"ScalerCrop": new_crop})
 
         self.pi_streamer.command_service.add_output_data(
-            data=f"{OutputCommandType.ZOOM_FACTOR.value} {self.current_zoom}"
+            data=f"{OutputCommandType.ZOOM_LEVEL.value} {self.current_zoom}"
         )
 
         if self.pi_streamer.verbose:

--- a/command_controller.py
+++ b/command_controller.py
@@ -3,7 +3,6 @@
 from time import time
 from typing import Any, Literal, Union
 from constants import (
-    DEFAULT_MAX_ZOOM,
     MIN_ZOOM,
     ZOOM_RATE,
     CommandType,
@@ -22,7 +21,6 @@ class CommandController:
         self.pi_streamer._set_command_controller(self)
         self.zoom_status = ZoomStatus.STOP.value
         self.current_zoom = MIN_ZOOM
-        self.max_zoom = DEFAULT_MAX_ZOOM
         self.last_zoom_time = 0
 
     def handle_command(self, command_type: str, command_value: str = "") -> None:
@@ -56,7 +54,7 @@ class CommandController:
                 raise Exception(
                     f"Error: {max_zoom} is not a valid max_zoom. It must be between 8.0 and 16.0 inclusive."
                 )
-            self.max_zoom = max_zoom
+            self.pi_streamer.max_zoom = max_zoom
             self.set_zoom(MIN_ZOOM)  # reset the zoom back to the original
         elif command_type == CommandType.STABILIZE.value:
             try:
@@ -168,8 +166,8 @@ class CommandController:
         # Adjust the zoom by setting the crop rectangle
         if zoom_factor <= MIN_ZOOM:
             zoom_factor = MIN_ZOOM
-        elif zoom_factor >= self.max_zoom:
-            zoom_factor = self.max_zoom
+        elif zoom_factor >= self.pi_streamer.max_zoom:
+            zoom_factor = self.pi_streamer.max_zoom
 
         self.current_zoom = round(zoom_factor, 2)
         x, y, width, height = self.pi_streamer.picam2.camera_controls["ScalerCrop"][1]
@@ -224,8 +222,8 @@ class CommandController:
         if self.current_zoom <= MIN_ZOOM:
             self.current_zoom = MIN_ZOOM
             stop_zoom = True
-        elif self.current_zoom >= self.max_zoom:
-            self.current_zoom = self.max_zoom
+        elif self.current_zoom >= self.pi_streamer.max_zoom:
+            self.current_zoom = self.pi_streamer.max_zoom
             stop_zoom = True
 
         if stop_zoom:

--- a/command_service.py
+++ b/command_service.py
@@ -45,7 +45,7 @@ class CommandService:
         This is a way to write to the output FIFO queue.
         """
         try:
-            fifo_output_write = os.open(OUTPUT_FIFO_PATH, os.O_WRONLY)
+            fifo_output_write = os.open(OUTPUT_FIFO_PATH, os.O_RDWR | os.O_NONBLOCK)
             os.write(fifo_output_write, f"{data}\n".encode())
             os.close(fifo_output_write)
         except Exception as e:

--- a/constants.py
+++ b/constants.py
@@ -2,8 +2,8 @@ from typing import Final
 from enum import Enum
 
 FRAMERATE: Final = 30
-MIN_ZOOM: Final = 1.05
-MAX_ZOOM: Final = 16.0
+MIN_ZOOM: Final = 1.0
+DEFAULT_MAX_ZOOM = 16.0  # this has the potential to change
 DEFAULT_CONFIG_PATH: Final = "477-Pi4.json"
 STREAMING_FRAMESIZE: Final = "1280x720"  # 720p
 STILL_FRAMESIZE: Final = "3840x2160"  # 4K
@@ -13,6 +13,10 @@ ZOOM_RATE: Final = 1.65  # zoom rate per second
 
 
 class CommandType(Enum):
+    """
+    Commands pistreamer reads from FIFO from other processes
+    """
+
     STOP = "stop"
     KILL = "kill"
     BITRATE = "bitrate"
@@ -26,10 +30,19 @@ class CommandType(Enum):
     START_GCS_STREAM = "start_gcs_stream"
     STOP_GCS_STREAM = "stop_gcs_stream"
     ZOOM = "zoom"
+    MAX_ZOOM = "max_zoom"
     TAKE_PHOTO = "take_photo"
     ATAK_HOST = "atak_host"  # `atak_host 192.168.1.1:5600` is an example
     STOP_ATAK = "stop_atak"
     STABILIZE = "stabilize"
+
+
+class OutputCommandType(Enum):
+    """
+    Commands pistreamer writes to FIFO for other processes to read
+    """
+
+    ZOOM_FACTOR = "zoomFactor"
 
 
 class ZoomStatus(Enum):

--- a/constants.py
+++ b/constants.py
@@ -42,7 +42,7 @@ class OutputCommandType(Enum):
     Commands pistreamer writes to FIFO for other processes to read
     """
 
-    ZOOM_FACTOR = "zoomFactor"
+    ZOOM_LEVEL = "zoomLevel"  # defined at https://mavlink.io/en/messages/common.html#CAMERA_SETTINGS
 
 
 class ZoomStatus(Enum):

--- a/pistreamer_v2.py
+++ b/pistreamer_v2.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import sys
 from constants import (
     DEFAULT_CONFIG_PATH,
+    DEFAULT_MAX_ZOOM,
     FRAMERATE,
     MIN_ZOOM,
     STREAMING_FRAMESIZE,
@@ -39,6 +40,7 @@ class PiStreamer2:
         atak_port: Optional[Union[str, int]] = None,
         config_file: str = "./477-Pi4.json",
         verbose: bool = False,
+        max_zoom: float = DEFAULT_MAX_ZOOM,
     ) -> None:
         # utilities
         from command_controller import CommandController
@@ -55,6 +57,7 @@ class PiStreamer2:
         self.streaming_bitrate = streaming_bitrate
         self.original_size = (0, 0)
         self.recording_start_time = 0
+        self.max_zoom = max_zoom
         # stabilize settings
         self.stabilize = stabilize
         self.prev_gray = None
@@ -429,6 +432,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--verbose", action="store_true", help="Whether to print verbose FPS data"
     )
+    parser.add_argument(
+        "--max_zoom",
+        type=float,
+        default=DEFAULT_MAX_ZOOM,
+        help="Max Zoom rate of the EO",
+    )
     args = parser.parse_args()
     try:
         Validator(args)
@@ -445,6 +454,7 @@ if __name__ == "__main__":
         atak_port=args.atak_port,
         config_file=args.config_file,
         verbose=args.verbose,
+        max_zoom=args.max_zoom,
     )
     from command_controller import CommandController
 

--- a/pistreamer_v2.py
+++ b/pistreamer_v2.py
@@ -316,7 +316,7 @@ class PiStreamer2:
 
         # Init frame and stream
         fps = []
-        self.start_gcs_stream(ip=self.gcs_ip, port=self.gcs_port)  # type: ignore
+        self.start_gcs_stream(ip=str(self.gcs_ip), port=str(self.gcs_port))
         self.command_controller.set_zoom(MIN_ZOOM)
 
         # Main loop

--- a/validator.py
+++ b/validator.py
@@ -20,6 +20,7 @@ class Validator:
         ret &= self.validate_port(str(self.args.atak_port))
         ret &= self.validate_bitrate(int(self.args.bitrate))
         ret &= self.is_json_file(str(self.args.config_file))
+        ret &= self.validate_max_zoom(float(self.args.max_zoom))
         return ret
 
     def validate_ip(self, ip: str) -> bool:
@@ -45,9 +46,9 @@ class Validator:
         except ValueError:
             return False
 
-    def validate_max_zoom(self, bitrate: float) -> bool:
+    def validate_max_zoom(self, max_zoom: float) -> bool:
         try:
-            if 8.0 <= bitrate <= 16.0:
+            if 8.0 <= max_zoom <= 16.0:
                 return True
             return False
         except ValueError:

--- a/validator.py
+++ b/validator.py
@@ -45,5 +45,13 @@ class Validator:
         except ValueError:
             return False
 
+    def validate_max_zoom(self, bitrate: float) -> bool:
+        try:
+            if 8.0 <= bitrate <= 16.0:
+                return True
+            return False
+        except ValueError:
+            return False
+
     def is_json_file(str, file_name: str) -> bool:
         return os.path.isfile(file_name) and file_name.lower().endswith(".json")


### PR DESCRIPTION
* Before the first few zoomed frames changed the aspact ratio slightly. Now, zooming in is smooth and doesn't squeeze the frame.
* The zoom level is now outputted to a fifo so that the gcs can display the zoom level.
* A command has been added to modify max zoom while running.
* Reverted some readme changes