### PR TITLE
Accept file names for photos and recordings

### DIFF
--- a/command_controller.py
+++ b/command_controller.py
@@ -28,8 +28,11 @@ class CommandController:
         Attempts to handle the GCS commands for PiStreamer. If an exception occurs it is
         raised so PiStreamer can update the db row with the error.
         """
-        if command_type == CommandType.RECORD.value:
-            self.pi_streamer.start_recording()
+        # Higher priority commands should come first in if/elif/else for minor performance improvements
+        if command_type == CommandType.TAKE_PHOTO.value:
+            self.pi_streamer.take_photo(file_name=command_value)
+        elif command_type == CommandType.RECORD.value:
+            self.pi_streamer.start_recording(file_name=command_value)
         elif command_type == CommandType.ZOOM.value:
             try:
                 zoom_status = str(command_value).lower().strip()
@@ -64,8 +67,6 @@ class CommandController:
                 self.pi_streamer.stabilize = stab_value
             except Exception:
                 raise Exception("Invalid stabilization command.")
-        elif command_type == CommandType.TAKE_PHOTO.value:
-            self.pi_streamer.take_photo()
         elif command_type == CommandType.STOP_RECORDING.value:
             self.pi_streamer.stop_recording()
         elif command_type == CommandType.GCS_HOST.value:

--- a/constants.py
+++ b/constants.py
@@ -10,6 +10,7 @@ STILL_FRAMESIZE: Final = "3840x2160"  # 4K
 INPUT_FIFO_PATH: Final = "/tmp/pistreamer"
 OUTPUT_FIFO_PATH: Final = "/tmp/pistreamer_output"
 ZOOM_RATE: Final = 1.65  # zoom rate per second
+MEDIA_FILES_DIRECTORY: Final = "MediaFiles"
 
 
 class CommandType(Enum):

--- a/constants.py
+++ b/constants.py
@@ -14,24 +14,23 @@ ZOOM_RATE: Final = 1.65  # zoom rate per second
 
 class CommandType(Enum):
     """
-    Commands pistreamer reads from FIFO from other processes
+    Commands pistreamer reads from FIFO from other processes.
+    Some commands require a value to be passed with them and others are standalone.
     """
 
     STOP = "stop"
     KILL = "kill"
-    BITRATE = "bitrate"
-    GCS_IP = "gcs_ip"
-    GCS_PORT = "gcs_port"
-    GCS_HOST = (
-        "gsc_host"  # use this if you want to change ip address and port simultaneously
-    )
-    RECORD = "record"
+    BITRATE = "bitrate"  # `bitrate 2500` is an example`
+    GCS_IP = "gcs_ip"  # `gcs_ip 192.168.1.50` is an example
+    GCS_PORT = "gcs_port"  # `gcs_port 5601` is an example
+    GCS_HOST = "gsc_host"  # `gsc_host 192.168.1.50:5601` is an example
+    RECORD = "record"  # record <Optional: file_name>` is an example
     STOP_RECORDING = "stop_recording"
     START_GCS_STREAM = "start_gcs_stream"
     STOP_GCS_STREAM = "stop_gcs_stream"
-    ZOOM = "zoom"
-    MAX_ZOOM = "max_zoom"
-    TAKE_PHOTO = "take_photo"
+    ZOOM = "zoom"  # `zoom 1.0`, `zoom in`, `zoom stop` are examples
+    MAX_ZOOM = "max_zoom"  # `max_zoom 8.0` is an example
+    TAKE_PHOTO = "take_photo"  # `take_photo <Optional: file_name>` is an example
     ATAK_HOST = "atak_host"  # `atak_host 192.168.1.1:5600` is an example
     STOP_ATAK = "stop_atak"
     STABILIZE = "stabilize"

--- a/ffmpeg_configs.py
+++ b/ffmpeg_configs.py
@@ -2,7 +2,9 @@ from typing import List, Tuple
 from utils import get_timestamp
 
 
-def get_ffmpeg_command_record(resolution: Tuple[int, ...], framerate: str) -> List[str]:
+def get_ffmpeg_command_record(
+    resolution: Tuple[int, ...], framerate: str, file_name: str
+) -> List[str]:
     # Used for saving data to disk
     return [
         "ffmpeg",
@@ -30,7 +32,7 @@ def get_ffmpeg_command_record(resolution: Tuple[int, ...], framerate: str) -> Li
         "+faststart",  # Prepare the file for playback
         "-f",
         "mpegts",  # Save to mpegts
-        f"{get_timestamp()}.ts",  # Output file pattern
+        file_name,  # Output file pattern
     ]
 
 

--- a/pistreamer_v2.py
+++ b/pistreamer_v2.py
@@ -83,7 +83,7 @@ class PiStreamer2:
         self._close_ffmpeg_processes()
 
         self.ffmpeg_command_record = get_ffmpeg_command_record(
-            self.resolution, str(FRAMERATE)
+            self.resolution, str(FRAMERATE), f"{get_timestamp()}.ts"
         )
         print(f"streaming_bitrate {str(self.streaming_bitrate)}")
         if self.gcs_ip and self.gcs_port:
@@ -163,11 +163,18 @@ class PiStreamer2:
 
         return stabilized_frame
 
-    def start_recording(self) -> None:
+    def start_recording(self, file_name: str = "") -> None:
         if self.is_recording:
             print("Already recording...")
             return
+
         self.recording_start_time = int(time.time())
+
+        if file_name:
+            self.ffmpeg_command_record = get_ffmpeg_command_record(
+                self.resolution, str(FRAMERATE), file_name
+            )
+
         self.ffmpeg_process_record = subprocess.Popen(  # type: ignore
             self.ffmpeg_command_record, stdin=subprocess.PIPE
         )
@@ -233,12 +240,14 @@ class PiStreamer2:
                 self.ffmpeg_process_atak.stdin.close()
             self.ffmpeg_process_atak.wait()
 
-    def take_photo(self) -> None:
+    def take_photo(self, file_name: str = "") -> None:
         """
         Since photos are taken at higher resolution than streaming, the picam2 must stop and
         be reconfigured before the photo can be taken. Once taken, the streaming config is reapplied.
         If the photo resolution is the same as the streaming resolution, the picam2 does not need to
         change resolution.
+
+        Also note that the command sender may optionally send the desired file name for the photo.
         """
         if not self.is_gcs_streaming:
             return
@@ -251,7 +260,9 @@ class PiStreamer2:
             self.picam2.configure(self.photo_config)
             self.picam2.start()
 
-        self.picam2.capture_file(f"{get_timestamp()}.jpg")
+        if not file_name:
+            file_name = f"{get_timestamp()}.jpg"
+        self.picam2.capture_file(file_name)
 
         if not is_same_resolution:
             self.picam2.stop()

--- a/pistreamer_v2.py
+++ b/pistreamer_v2.py
@@ -7,6 +7,8 @@ from ffmpeg_configs import (
     get_ffmpeg_command_record,
     get_ffmpeg_command_gcs,
 )
+import os
+from pathlib import Path
 from picamera2 import Picamera2
 import cv2
 import numpy as np
@@ -19,6 +21,7 @@ from constants import (
     DEFAULT_CONFIG_PATH,
     DEFAULT_MAX_ZOOM,
     FRAMERATE,
+    MEDIA_FILES_DIRECTORY,
     MIN_ZOOM,
     STREAMING_FRAMESIZE,
     STILL_FRAMESIZE,
@@ -79,11 +82,17 @@ class PiStreamer2:
         self.ffmpeg_process_gcs = None
         self.ffmpeg_process_atak = None
 
+        # Ensure the media files directory exists
+        media_directory = Path(f"./{MEDIA_FILES_DIRECTORY}")
+        os.makedirs(media_directory, exist_ok=True)
+
     def _init_ffmpeg_processes(self) -> None:
         self._close_ffmpeg_processes()
 
         self.ffmpeg_command_record = get_ffmpeg_command_record(
-            self.resolution, str(FRAMERATE), f"{get_timestamp()}.ts"
+            self.resolution,
+            str(FRAMERATE),
+            f"./{MEDIA_FILES_DIRECTORY}/{get_timestamp()}.ts",
         )
         print(f"streaming_bitrate {str(self.streaming_bitrate)}")
         if self.gcs_ip and self.gcs_port:
@@ -261,7 +270,7 @@ class PiStreamer2:
             self.picam2.start()
 
         if not file_name:
-            file_name = f"{get_timestamp()}.jpg"
+            file_name = f"./{MEDIA_FILES_DIRECTORY}/{get_timestamp()}.jpg"
         self.picam2.capture_file(file_name)
 
         if not is_same_resolution:


### PR DESCRIPTION
- The command sender now has the option to specify the desired file_name of the photo or recording.
- If not specified in the command_value, then the pistreamer will generate one and co-locate in the same location as the pistreamer script (in a photo called `MediaFiles`.