### PR TITLE
Use sockets to send commands to pistreamer_v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # PiStreamer
-This is a Python application using the picamera2 library to open a camera on an RPi and perform a series of commands:
+This is a Python application using the picamera2 library to open a camera on an RPi and perform a series of commands. A full list of support commands can be found at `CommandType`. Here are some common examples:
 * Streaming to UDP GCS destination
 * Streaming to ATAK
 * Capturing still photos
 * Recording video
 * Changing the digital zoom of the frame
+* Stabilizing the stream
 
 ## Dependencies
 Tested on RPi4 CM running Raspian:
@@ -28,23 +29,22 @@ For normal (non-daemon) functionality run the script as below:
 ```
 python pistreamer_v2.py --gcs_ip={IP Address} --gcs_port={Port} --config_file="./477-Pi4.json"
 ```
-Once the app is running you can send a variety of commands (from a different session) via a FIFO by executing `_command_tester.py`.
+Once the app is running you can send a variety of commands (from a different session) by sending data over a socket defined by `SOCKET_HOST:CMD_SOCKET_PORT`. `_command_tester.py` has several examples you can uncomment and/or modify.
 
 ## Commands
-You can run `python _command_tester.py` to writes to the FIFO which the pistreamer will ingest. Below are some examples:
+You can run `python _command_tester.py` to send data over the cmd socket which the pistreamer will ingest. Below are some examples:
 ```
-command_service = CommandService()
-command_service.add_input_command(command_type=CommandType.ZOOM.value, command_value="1.0") #zoom out fully
-command_service.add_input_command(command_type=CommandType.ZOOM.value, command_value="8.0") #zoom in fully
-command_service.add_input_command(command_type=CommandType.BITRATE.value, command_value="2000") #set bitrate to 2000 kpbs
-command_service.add_input_command(command_type=CommandType.IP_ADDRESS.value, command_value="192.168.1.85") #change endpoint ip to 192.168.1.85
-command_service.add_input_command(command_type=CommandType.PORT.value, command_value="5601") #change endpoint port to 5601
-command_service.add_input_command(command_type=CommandType.RECORD.value) #start recording to mp4
-command_service.add_input_command(command_type=CommandType.STOP_RECORDING) #stop recording to mp4
-command_service.add_input_command(command_type=CommandType.TAKE_PHOTO) #take single frame photo at 4K resolution.
-command_service.add_input_command(command_type=CommandType.START_GCS_STREAM) #start the GCS feed
-command_service.add_input_command(command_type=CommandType.STABILIZE, command_value="start") #start stabilization at current framerate
-command_service.add_input_command(command_type=CommandType.STABILIZE, command_value="stop") #stop stabilization at current framerate
+_send_data(command_type=CommandType.ZOOM.value, command_value="1.0") #zoom out fully
+_send_data(command_type=CommandType.ZOOM.value, command_value="8.0") #zoom in fully
+_send_data(command_type=CommandType.BITRATE.value, command_value="2000") #set bitrate to 2000 kpbs
+_send_data(command_type=CommandType.IP_ADDRESS.value, command_value="192.168.1.85") #change endpoint ip to 192.168.1.85
+_send_data(command_type=CommandType.PORT.value, command_value="5601") #change endpoint port to 5601
+_send_data(command_type=CommandType.RECORD.value) #start recording to mp4
+_send_data(command_type=CommandType.STOP_RECORDING) #stop recording to mp4
+_send_data(command_type=CommandType.TAKE_PHOTO) #take single frame photo at 4K resolution.
+_send_data(command_type=CommandType.START_GCS_STREAM) #start the GCS feed
+_send_data(command_type=CommandType.STABILIZE, command_value="start") #start stabilization at current framerate
+_send_data(command_type=CommandType.STABILIZE, command_value="stop") #stop stabilization at current framerate
 ```
 
 ## Daemon operation

--- a/_command_tester.py
+++ b/_command_tester.py
@@ -1,46 +1,50 @@
 #!/usr/bin/env python3
 
 from command_service import CommandService
-from constants import CommandType
+from constants import CMD_SOCKET_PORT, SOCKET_HOST, CommandType
 import time
 
-command_service = CommandService()
+
+def _send_data(command_type: CommandType, command_value: str = "") -> None:
+    data = f"{command_type.value} {command_value}".strip()
+    CommandService.send_data_out(data=data, host=SOCKET_HOST, port=CMD_SOCKET_PORT)
+
 
 # Modify the command_type and command_value as needed=
 
 #######-####### BITRATE #######-#######
-# command_service.add_input_command(command_type=CommandType.BITRATE, command_value="2010")
+# _send_data(command_type=CommandType.BITRATE, command_value="2010")
 
 #######-####### ZOOM #######-#######
-command_service.add_input_command(command_type=CommandType.ZOOM, command_value="1.0")
-# command_service.add_input_command(command_type=CommandType.MAX_ZOOM, command_value="8.0")
-# command_service.add_input_command(command_type=CommandType.ZOOM, command_value="in")
-# command_service.add_input_command(command_type=CommandType.ZOOM, command_value="out")
+# _send_data(command_type=CommandType.ZOOM, command_value="5.0")
+# _send_data(command_type=CommandType.MAX_ZOOM, command_value="8.0")
+_send_data(command_type=CommandType.ZOOM, command_value="in")
+# _send_data(command_type=CommandType.ZOOM, command_value="out")
 # time.sleep(2)
-# command_service.add_input_command(command_type=CommandType.ZOOM, command_value="stop")
+# _send_data(command_type=CommandType.ZOOM, command_value="stop")
 
 #######-####### PHOTO #######-#######
-# command_service.add_input_command(command_type=CommandType.TAKE_PHOTO)
+# _send_data(command_type=CommandType.TAKE_PHOTO)
 
 #######-####### ATAK #######-#######
-# command_service.add_input_command(
+# _send_data(
 #     command_type=CommandType.ATAK_HOST, command_value="224.1.1.1:5002"
 # )
 
 #######-####### GCS #######-#######
-# command_service.add_input_command(command_type=CommandType.GCS_IP, command_value="192.168.1.124")
-# command_service.add_input_command(command_type=CommandType.GCS_PORT, command_value="5600")
-# command_service.add_input_command(command_type=CommandType.GCS_HOST, command_value="192.168.1.124:5600")
-# command_service.add_input_command(command_type=CommandType.START_GCS_STREAM)
-# command_service.add_input_command(command_type=CommandType.STOP_GCS_STREAM)
+# _send_data(command_type=CommandType.GCS_IP, command_value="192.168.1.124")
+# _send_data(command_type=CommandType.GCS_PORT, command_value="5600")
+# _send_data(command_type=CommandType.GCS_HOST, command_value="192.168.1.124:5600")
+# _send_data(command_type=CommandType.START_GCS_STREAM)
+# _send_data(command_type=CommandType.STOP_GCS_STREAM)
 
 #######-####### RECORD #######-#######
-# command_service.add_input_command(command_type=CommandType.RECORD)
+# _send_data(command_type=CommandType.RECORD)
 # time.sleep(15)
-# command_service.add_input_command(command_type=CommandType.STOP_RECORDING)
+# _send_data(command_type=CommandType.STOP_RECORDING)
 
 #######-####### STABILIZE #######-#######
-# command_service.add_input_command(command_type=CommandType.STABILIZE, command_value="start")
-# command_service.add_input_command(
+# _send_data(command_type=CommandType.STABILIZE, command_value="start")
+# _send_data(
 #     command_type=CommandType.STABILIZE, command_value="stop"
 # )

--- a/command_controller.py
+++ b/command_controller.py
@@ -2,12 +2,15 @@
 
 from time import time
 from typing import Any, Literal, Union
+from command_service import CommandService
 from constants import (
     MIN_ZOOM,
     ZOOM_RATE,
     CommandType,
     OutputCommandType,
     ZoomStatus,
+    SOCKET_HOST,
+    OUTPUT_SOCKET_PORT,
 )
 from validator import Validator
 
@@ -120,10 +123,6 @@ class CommandController:
                 raise Exception(
                     "Invalid ip command. Use 'ip <value>' where value is a valid ip address."
                 )
-        elif command_type == CommandType.STOP.value:
-            self.pi_streamer.stop_and_clean_all()
-        elif command_type == CommandType.KILL.value:
-            self.pi_streamer.stop_and_clean_all()
         else:
             raise Exception(f"Unknown command_type: `{command_type}`")
 
@@ -187,8 +186,10 @@ class CommandController:
         # Set the updated ScalerCrop for the second stream
         self.pi_streamer.picam2.set_controls({"ScalerCrop": new_crop})
 
-        self.pi_streamer.command_service.add_output_data(
-            data=f"{OutputCommandType.ZOOM_LEVEL.value} {self.current_zoom}"
+        CommandService.send_data_out(
+            data=f"{OutputCommandType.ZOOM_LEVEL.value} {self.current_zoom}",
+            host=SOCKET_HOST,
+            port=OUTPUT_SOCKET_PORT,
         )
 
         if self.pi_streamer.verbose:

--- a/constants.py
+++ b/constants.py
@@ -7,20 +7,20 @@ DEFAULT_MAX_ZOOM = 16.0  # this has the potential to change
 DEFAULT_CONFIG_PATH: Final = "477-Pi4.json"
 STREAMING_FRAMESIZE: Final = "1280x720"  # 720p
 STILL_FRAMESIZE: Final = "3840x2160"  # 4K
-INPUT_FIFO_PATH: Final = "/tmp/pistreamer"
-OUTPUT_FIFO_PATH: Final = "/tmp/pistreamer_output"
 ZOOM_RATE: Final = 1.65  # zoom rate per second
 MEDIA_FILES_DIRECTORY: Final = "MediaFiles"
+SOCKET_HOST = "localhost"
+CMD_SOCKET_PORT = 54321
+OUTPUT_SOCKET_PORT = 54322
+MAX_SOCKET_CONNECTIONS = 3
 
 
 class CommandType(Enum):
     """
-    Commands pistreamer reads from FIFO from other processes.
+    Commands pistreamer reads from a defined socket which is sent data by other processes.
     Some commands require a value to be passed with them and others are standalone.
     """
 
-    STOP = "stop"
-    KILL = "kill"
     BITRATE = "bitrate"  # `bitrate 2500` is an example`
     GCS_IP = "gcs_ip"  # `gcs_ip 192.168.1.50` is an example
     GCS_PORT = "gcs_port"  # `gcs_port 5601` is an example
@@ -39,7 +39,7 @@ class CommandType(Enum):
 
 class OutputCommandType(Enum):
     """
-    Commands pistreamer writes to FIFO for other processes to read
+    Commands pistreamer writes to an output socket for other processes to read
     """
 
     ZOOM_LEVEL = "zoomLevel"  # defined at https://mavlink.io/en/messages/common.html#CAMERA_SETTINGS


### PR DESCRIPTION
* `pistreamer_v2.py` will now read create a server socket at `CMD_SOCKET_PORT`  and listen for incoming data in a non blocking fashion. Too see how to send data commands to the app see `_send_data`.
* `pistreamer_v2.py` will also send data out on a client socket to `OUTPUT_SOCKET_PORT ` so other processes can receive that data. Note, that other process will need to manage the server on `OUTPUT_SOCKET_PORT`. The reason we need a different port is so that the app doesn't send itself data.
* `STOP` and `KILL` commands are removed.
```
SOCKET_HOST = "localhost"
CMD_SOCKET_PORT = 54321
OUTPUT_SOCKET_PORT = 54322
MAX_SOCKET_CONNECTIONS = 3
```
### NO MORE FIFOS!