### PR TITLE
ATAK or QGC GCS Control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.mp4
 *.jpg
+*.vscode
+*__pycache__

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pistreamer_v2 has the option to stream to QGroundControl as the GCS or ATAK. Gen
 For normal (non-daemon) functionality run the script as below:
 
 ```
-python pistreamer_v2.py --gcs_ip={IP Address} --gcs_port={Port} --config_file="./477-Pi4.json"
+python pistreamer_v2.py --qgc_ip={IP Address} --qgc_port={Port} --config_file="./477-Pi4.json"
 ```
 Once the app is running you can send a variety of commands (from a different session) by sending data over a socket defined by `SOCKET_HOST:CMD_SOCKET_PORT`. `_command_tester.py` has several examples you can uncomment and/or modify.
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ _send_data(command_type=CommandType.TAKE_PHOTO) #take single frame photo at 4K r
 _send_data(command_type=CommandType.START_GCS_STREAM) #start the GCS feed
 _send_data(command_type=CommandType.STABILIZE, command_value="start") #start stabilization at current framerate
 _send_data(command_type=CommandType.STABILIZE, command_value="stop") #stop stabilization at current framerate
+_send_data(command_type=CommandType.ACTIVE_GCS, command_value="atak") #stream atak mpeg-ts to current gcs ip and port
 ```
 
 ## Service operation

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pistreamer_v2 has the option to stream to QGroundControl as the GCS or ATAK. Gen
 For normal (non-daemon) functionality run the script as below:
 
 ```
-python pistreamer_v2.py --qgc_ip={IP Address} --qgc_port={Port} --config_file="./477-Pi4.json"
+python pistreamer_v2.py --gcs_ip={IP Address} --gcs_port={Port} --config_file="./477-Pi4.json"
 ```
 Once the app is running you can send a variety of commands (from a different session) by sending data over a socket defined by `SOCKET_HOST:CMD_SOCKET_PORT`. `_command_tester.py` has several examples you can uncomment and/or modify.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ sudo apt install -y ffmpeg
 sudo apt install -y python3-opencv
 sudo apt install -y python3-numpy
 ```
+## GCS Selection
+pistreamer_v2 has the option to stream to QGroundControl as the GCS or ATAK. Generally speaking ATAK requires a MPEG-TS video format whereas GCS is a RDP stream. Since a pilot will only need one active GCS at a time, either `ffmpeg_command_atak` or `ffmpeg_command_qgc` will be actively streaming at a time.
 
 ## Non-Daemon operation
 For normal (non-daemon) functionality run the script as below:
@@ -47,21 +49,8 @@ _send_data(command_type=CommandType.STABILIZE, command_value="start") #start sta
 _send_data(command_type=CommandType.STABILIZE, command_value="stop") #stop stabilization at current framerate
 ```
 
-## Daemon operation
-To run the streamer and all ffmpeg processes in the background run the following:
-```
-python pistreamer_v2.py &
-```
-
-### To kill the dameon
-```
-echo "kill" > /tmp/pistreamer
-```
-Alternatively you can find the daemon and kill it
-```
-ps -ax | grep pistreamer_v2
-sudo kill -9 {PROCESS_ID_FOUND_ABOVE}
-```
+## Service operation
+To run the streamer and all ffmpeg processes in the background configure the script to be a service on the rpi.
 
 ## Stabilization
 Pass the flag `--stabilization` to the command line to achieve software image stabilization through opencv. Due to the computational overhead of stabilization, a significant FPS penalty is incurred at all resolutions. See the spec table below to evaluate the best options.

--- a/_command_tester.py
+++ b/_command_tester.py
@@ -34,11 +34,11 @@ def _send_data(command_type: CommandType, command_value: str = "") -> None:
 _send_data(command_type=CommandType.GCS_HOST, command_value="192.168.1.124:5600")
 
 #######-####### QGC #######-#######
-# _send_data(command_type=CommandType.QGC_IP, command_value="192.168.1.124")
-# _send_data(command_type=CommandType.QGC_PORT, command_value="5600")
-# _send_data(command_type=CommandType.QGC_HOST, command_value="192.168.1.124:5600")
-# _send_data(command_type=CommandType.START_QGC_STREAM)
-# _send_data(command_type=CommandType.STOP_QGC_STREAM)
+# _send_data(command_type=CommandType.GCS_IP, command_value="192.168.1.124")
+# _send_data(command_type=CommandType.GCS_PORT, command_value="5600")
+# _send_data(command_type=CommandType.GCS_HOST, command_value="192.168.1.124:5600")
+# _send_data(command_type=CommandType.START_GCS_STREAM)
+# _send_data(command_type=CommandType.STOP_GCS_STREAM)
 
 #######-####### RECORD #######-#######
 # _send_data(command_type=CommandType.RECORD)

--- a/_command_tester.py
+++ b/_command_tester.py
@@ -13,7 +13,7 @@ def _send_data(command_type: CommandType, command_value: str = "") -> None:
 # Modify the command_type and command_value as needed=
 
 #######-####### BITRATE #######-#######
-# _send_data(command_type=CommandType.BITRATE, command_value="2010")
+# _send_data(command_type=CommandType.BITRATE, command_value="3000")
 
 #######-####### ZOOM #######-#######
 # _send_data(command_type=CommandType.ZOOM, command_value="4.0")
@@ -54,4 +54,4 @@ def _send_data(command_type: CommandType, command_value: str = "") -> None:
 # )
 
 #######-####### TRACKING #######-#######
-_send_data(command_type=CommandType.INIT_TRACKING_POI, command_value="560,290")
+# _send_data(command_type=CommandType.INIT_TRACKING_POI, command_value="560,290")

--- a/_command_tester.py
+++ b/_command_tester.py
@@ -31,9 +31,7 @@ def _send_data(command_type: CommandType, command_value: str = "") -> None:
 # _send_data(command_type=CommandType.TAKE_PHOTO)
 
 #######-####### ATAK #######-#######
-# _send_data(
-#     command_type=CommandType.ATAK_HOST, command_value="224.1.1.1:5002"
-# )
+_send_data(command_type=CommandType.GCS_HOST, command_value="192.168.1.124:5600")
 
 #######-####### QGC #######-#######
 # _send_data(command_type=CommandType.QGC_IP, command_value="192.168.1.124")

--- a/_command_tester.py
+++ b/_command_tester.py
@@ -35,12 +35,12 @@ def _send_data(command_type: CommandType, command_value: str = "") -> None:
 #     command_type=CommandType.ATAK_HOST, command_value="224.1.1.1:5002"
 # )
 
-#######-####### GCS #######-#######
-# _send_data(command_type=CommandType.GCS_IP, command_value="192.168.1.124")
-# _send_data(command_type=CommandType.GCS_PORT, command_value="5600")
-# _send_data(command_type=CommandType.GCS_HOST, command_value="192.168.1.124:5600")
-# _send_data(command_type=CommandType.START_GCS_STREAM)
-# _send_data(command_type=CommandType.STOP_GCS_STREAM)
+#######-####### QGC #######-#######
+# _send_data(command_type=CommandType.QGC_IP, command_value="192.168.1.124")
+# _send_data(command_type=CommandType.QGC_PORT, command_value="5600")
+# _send_data(command_type=CommandType.QGC_HOST, command_value="192.168.1.124:5600")
+# _send_data(command_type=CommandType.START_QGC_STREAM)
+# _send_data(command_type=CommandType.STOP_QGC_STREAM)
 
 #######-####### RECORD #######-#######
 # _send_data(command_type=CommandType.RECORD)

--- a/_command_tester.py
+++ b/_command_tester.py
@@ -13,7 +13,7 @@ def _send_data(command_type: CommandType, command_value: str = "") -> None:
 # Modify the command_type and command_value as needed=
 
 #######-####### BITRATE #######-#######
-# _send_data(command_type=CommandType.BITRATE, command_value="3000")
+_send_data(command_type=CommandType.BITRATE, command_value="3000")
 
 #######-####### ZOOM #######-#######
 # _send_data(command_type=CommandType.ZOOM, command_value="4.0")
@@ -30,15 +30,13 @@ def _send_data(command_type: CommandType, command_value: str = "") -> None:
 #######-####### PHOTO #######-#######
 # _send_data(command_type=CommandType.TAKE_PHOTO)
 
-#######-####### ATAK #######-#######
-_send_data(command_type=CommandType.GCS_HOST, command_value="192.168.1.124:5600")
-
 #######-####### QGC #######-#######
 # _send_data(command_type=CommandType.GCS_IP, command_value="192.168.1.124")
 # _send_data(command_type=CommandType.GCS_PORT, command_value="5600")
 # _send_data(command_type=CommandType.GCS_HOST, command_value="192.168.1.124:5600")
 # _send_data(command_type=CommandType.START_GCS_STREAM)
 # _send_data(command_type=CommandType.STOP_GCS_STREAM)
+# _send_data(command_type=CommandType.ACTIVE_GCS, command_value="atak")
 
 #######-####### RECORD #######-#######
 # _send_data(command_type=CommandType.RECORD)

--- a/cam_utils.py
+++ b/cam_utils.py
@@ -1,0 +1,5 @@
+from datetime import datetime
+
+
+def get_timestamp() -> str:
+    return datetime.now().strftime("%Y-%m-%d_%H-%M-%S")

--- a/command_controller.py
+++ b/command_controller.py
@@ -222,7 +222,19 @@ class CommandController:
         """
         self.pi_streamer.stop_and_clean_all()
         self.pi_streamer.streaming_bitrate = bitrate
-        # TODO based on preferred_gcs_type start that stream
+
+        if self.pi_streamer.active_gcs == GCSType.QGC.value:
+            self.pi_streamer.start_qgc_stream(
+                ip=str(self.pi_streamer.qgc_ip),
+                port=str(self.pi_streamer.qgc_port),
+            )
+        elif self.pi_streamer.active_gcs == GCSType.ATAK.value:
+            self.pi_streamer.start_atak_stream(
+                ip=str(self.pi_streamer.atak_ip),
+                port=str(self.pi_streamer.atak_port),
+            )
+        else:
+            print("Invalid GCS type.")
 
     def set_zoom(self, zoom_factor: Union[int, float]) -> None:
         # Adjust the zoom by setting the crop rectangle

--- a/command_controller.py
+++ b/command_controller.py
@@ -134,6 +134,7 @@ class CommandController:
                 raise Exception(f"Unsupported GCS type {self.pi_streamer.active_gcs}.")
             stop_func()
         elif command_type == CommandType.ACTIVE_GCS.value:
+            command_value = command_value.lower().strip()
             if command_value not in [GCSType.QGC.value, GCSType.ATAK.value]:
                 raise Exception(f"Unsupported GCS type {self.pi_streamer.active_gcs}.")
             self._reset_gcs_host(
@@ -141,6 +142,20 @@ class CommandController:
                 port=str(self.pi_streamer.gcs_port),
                 gcs_type=command_value,
             )
+        elif command_type == CommandType.BITRATE.value:
+            try:
+                bitrate = int(command_value)
+                if not self.validator.validate_bitrate(bitrate):
+                    raise Exception(
+                        f"Error: {bitrate} is not a valid bitrate. It must be between 500 and 10000 kbps."
+                    )
+                print(f"Setting new bitrate: {bitrate} kbps")
+                bitrate = bitrate * 1000
+                self._reset_bitrate(bitrate)
+            except (IndexError, ValueError):
+                raise Exception(
+                    "Invalid bitrate command. Use 'bitrate <value>' where value is an int 500-10000 kbps."
+                )
         else:
             raise Exception(f"Unknown command_type: `{command_type}`")
 

--- a/constants.py
+++ b/constants.py
@@ -32,6 +32,8 @@ class CommandType(Enum):
     STOP_QGC_STREAM = "stop_qgc_stream"
     ### ^^^^
     ### vvvv Setting the ATAK host will start it and set it to preferred and stop the QGC stream
+    ATAK_IP = "atak_ip"  # `atak_ip 224.1.1.1` is an example and is usually multicast
+    ATAK_PORT = "atak_port"  # `atak_port 5002` is an example
     ATAK_HOST = "atak_host"  # `atak_host 224.1.1.1:5002` is an example
     START_ATAK_STREAM = "start_atak_stream"  # uses the ip/port set by the host
     STOP_ATAK_STREAM = "stop_atak_stream"
@@ -66,3 +68,8 @@ class TrackStatus(Enum):
     ACTIVE = "active"
     INIT = "init"
     NONE = "none"
+
+
+class GCSType(Enum):
+    QGC = "qgc"  # QGroundControl
+    ATAK = "atak"  # Android (Tactical Assault/Team Awareness) Kit

--- a/constants.py
+++ b/constants.py
@@ -24,19 +24,24 @@ class CommandType(Enum):
     Some commands require a value to be passed with them and others are standalone.
     """
 
+    ### vvvv Setting the IP, PORT, or HOST will start it and set it to preferred and stop the ATAK stream
+    QGC_IP = "qgc_ip"  # `qgc_ip 192.168.1.50` is an example
+    QGC_PORT = "qgc_port"  # `qgc_port 5601` is an example
+    QGC_HOST = "gsc_host"  # `gsc_host 192.168.1.50:5601` is an example
+    START_QGC_STREAM = "start_qgc_stream"  # uses the ip/port set by the above commands
+    STOP_QGC_STREAM = "stop_qgc_stream"
+    ### ^^^^
+    ### vvvv Setting the ATAK host will start it and set it to preferred and stop the QGC stream
+    ATAK_HOST = "atak_host"  # `atak_host 224.1.1.1:5002` is an example
+    START_ATAK_STREAM = "start_atak_stream"  # uses the ip/port set by the host
+    STOP_ATAK_STREAM = "stop_atak_stream"
+    ### ^^^^
     BITRATE = "bitrate"  # `bitrate 2500` is an example`
-    GCS_IP = "gcs_ip"  # `gcs_ip 192.168.1.50` is an example
-    GCS_PORT = "gcs_port"  # `gcs_port 5601` is an example
-    GCS_HOST = "gsc_host"  # `gsc_host 192.168.1.50:5601` is an example
     RECORD = "record"  # record <Optional: file_name>` is an example
     STOP_RECORDING = "stop_recording"
-    START_GCS_STREAM = "start_gcs_stream"
-    STOP_GCS_STREAM = "stop_gcs_stream"
     ZOOM = "zoom"  # `zoom 1.0`, `zoom in`, `zoom stop` are examples
     MAX_ZOOM = "max_zoom"  # `max_zoom 8.0` is an example
     TAKE_PHOTO = "take_photo"  # `take_photo <Optional: file_name>` is an example
-    ATAK_HOST = "atak_host"  # `atak_host 192.168.1.1:5600` is an example
-    STOP_ATAK = "stop_atak"
     STABILIZE = "stabilize"
     INIT_TRACKING_POI = "init_tracking_poi"  # `init_tracking_poi x,y` is an example
     STOP_TRACKING = "stop_tracking"

--- a/constants.py
+++ b/constants.py
@@ -24,19 +24,13 @@ class CommandType(Enum):
     Some commands require a value to be passed with them and others are standalone.
     """
 
-    ### vvvv Setting the IP, PORT, or HOST will start it and set it to preferred and stop the ATAK stream
-    QGC_IP = "qgc_ip"  # `qgc_ip 192.168.1.50` is an example
-    QGC_PORT = "qgc_port"  # `qgc_port 5601` is an example
-    QGC_HOST = "gsc_host"  # `gsc_host 192.168.1.50:5601` is an example
-    START_QGC_STREAM = "start_qgc_stream"  # uses the ip/port set by the above commands
-    STOP_QGC_STREAM = "stop_qgc_stream"
-    ### ^^^^
-    ### vvvv Setting the ATAK host will start it and set it to preferred and stop the QGC stream
-    ATAK_IP = "atak_ip"  # `atak_ip 224.1.1.1` is an example and is usually multicast
-    ATAK_PORT = "atak_port"  # `atak_port 5002` is an example
-    ATAK_HOST = "atak_host"  # `atak_host 224.1.1.1:5002` is an example
-    START_ATAK_STREAM = "start_atak_stream"  # uses the ip/port set by the host
-    STOP_ATAK_STREAM = "stop_atak_stream"
+    ### vvvv Setting the IP, PORT, or HOST will start the active GCS type (QGC or ATAK)
+    GCS_IP = "gcs_ip"  # `qgcgcs_ip_ip 192.168.1.50` is an example
+    GCS_PORT = "gcs_port"  # `gcs_port 5601` is an example
+    GCS_HOST = "gcs_host"  # `gcs_host 192.168.1.50:5601` is an example
+    START_GCS_STREAM = "start_gcs_stream"  # uses the ip/port set by the above commands
+    STOP_GCS_STREAM = "stop_gcs_stream"
+    ACTIVE_GCS = "active_gcs"  # `active_gcs atak` is an example
     ### ^^^^
     BITRATE = "bitrate"  # `bitrate 2500` is an example`
     RECORD = "record"  # record <Optional: file_name>` is an example

--- a/ffmpeg_configs.py
+++ b/ffmpeg_configs.py
@@ -35,14 +35,16 @@ def get_ffmpeg_command_record(
     ]
 
 
-def get_ffmpeg_command_gcs(
+def get_ffmpeg_command_qgc(
     resolution: Tuple[int, ...],
     framerate: str,
-    gcs_ip: str,
-    gcs_port: str,
+    qgc_ip: str,
+    qgc_port: str,
     streaming_bitrate: str,
 ) -> List[str]:
-    # Used for streaming video to GCS
+    """
+    Used for streaming video to QGroundControl as the GCS
+    """
     return [
         "ffmpeg",
         "-y",  # Overwrite output files without asking
@@ -68,7 +70,7 @@ def get_ffmpeg_command_gcs(
         "nobuffer",  # No buffer for RTP
         "-f",
         "rtp",  # Output format for RTP
-        f"rtp://{gcs_ip}:{gcs_port}",
+        f"rtp://{qgc_ip}:{qgc_port}",
     ]
 
 
@@ -79,7 +81,9 @@ def get_ffmpeg_command_atak(
     atak_port: str,
     streaming_bitrate: str,
 ) -> List[str]:
-    # Used for streaming video to ATAK
+    """
+    Used for streaming video to ATAK as the GCS
+    """
     return [
         "ffmpeg",
         "-y",  # Overwrite output files without asking

--- a/ffmpeg_configs.py
+++ b/ffmpeg_configs.py
@@ -38,8 +38,8 @@ def get_ffmpeg_command_record(
 def get_ffmpeg_command_qgc(
     resolution: Tuple[int, ...],
     framerate: str,
-    qgc_ip: str,
-    qgc_port: str,
+    gcs_ip: str,
+    gcs_port: str,
     streaming_bitrate: str,
 ) -> List[str]:
     """
@@ -70,7 +70,7 @@ def get_ffmpeg_command_qgc(
         "nobuffer",  # No buffer for RTP
         "-f",
         "rtp",  # Output format for RTP
-        f"rtp://{qgc_ip}:{qgc_port}",
+        f"rtp://{gcs_ip}:{gcs_port}",
     ]
 
 

--- a/pistreamer_v2.py
+++ b/pistreamer_v2.py
@@ -223,9 +223,12 @@ class PiStreamer2:
             str(self.qgc_port),
             str(self.streaming_bitrate),
         )
+        print(f"Starting QGC stream {self.ffmpeg_command_qgc}")
         self.ffmpeg_process_qgc = subprocess.Popen(  # type: ignore
             self.ffmpeg_command_qgc, stdin=subprocess.PIPE
         )
+        if not self.picam2.started:
+            self.picam2.start()
         self.is_qgc_streaming = True
 
     def stop_qgc_stream(self) -> None:
@@ -249,9 +252,12 @@ class PiStreamer2:
             str(self.atak_port),
             str(self.streaming_bitrate),
         )
+        print(f"Starting ATAK stream {self.ffmpeg_command_atak}")
         self.ffmpeg_process_atak = subprocess.Popen(  # type: ignore
             self.ffmpeg_command_atak, stdin=subprocess.PIPE
         )
+        if not self.picam2.started:
+            self.picam2.start()
         self.is_atak_streaming = True
 
     def stop_atak_stream(self) -> None:

--- a/validator.py
+++ b/validator.py
@@ -12,11 +12,11 @@ class Validator:
     def _validate_args(self) -> bool:
         if not self.args:
             return False
-        ret = self.validate_ip(str(self.args.gcs_ip))
+        ret = self.validate_ip(str(self.args.qgc_ip))
         if self.args.atak_ip:
             ret = self.validate_ip(str(self.args.atak_ip))
         if self.args.atak_port:
-            ret &= self.validate_port(str(self.args.gcs_port))
+            ret &= self.validate_port(str(self.args.qgc_port))
         ret &= self.validate_port(str(self.args.atak_port))
         ret &= self.validate_bitrate(int(self.args.bitrate))
         ret &= self.is_json_file(str(self.args.config_file))

--- a/validator.py
+++ b/validator.py
@@ -14,7 +14,7 @@ class Validator:
     def _validate_args(self) -> bool:
         if not self.args:
             return False
-        ret = self.validate_ip(str(self.args.gcs_ip))
+        ret = self.validate_ip(str(self.args.qgc_ip))
         if self.args.atak_ip:
             ret = self.validate_ip(str(self.args.atak_ip))
         if self.args.atak_port:

--- a/validator.py
+++ b/validator.py
@@ -14,12 +14,8 @@ class Validator:
     def _validate_args(self) -> bool:
         if not self.args:
             return False
-        ret = self.validate_ip(str(self.args.qgc_ip))
-        if self.args.atak_ip:
-            ret = self.validate_ip(str(self.args.atak_ip))
-        if self.args.atak_port:
-            ret &= self.validate_port(str(self.args.gcs_port))
-        ret &= self.validate_port(str(self.args.atak_port))
+        ret = self.validate_ip(str(self.args.gcs_ip))
+        ret &= self.validate_port(str(self.args.gcs_port))
         ret &= self.validate_bitrate(int(self.args.bitrate))
         ret &= self.is_json_file(str(self.args.config_file))
         ret &= self.validate_max_zoom(float(self.args.max_zoom))

--- a/validator.py
+++ b/validator.py
@@ -2,6 +2,8 @@ import os
 import ipaddress
 from typing import Any, Optional
 
+from constants import GCSType
+
 
 class Validator:
     def __init__(self, args: Optional[Any] = None) -> None:
@@ -12,15 +14,16 @@ class Validator:
     def _validate_args(self) -> bool:
         if not self.args:
             return False
-        ret = self.validate_ip(str(self.args.qgc_ip))
+        ret = self.validate_ip(str(self.args.gcs_ip))
         if self.args.atak_ip:
             ret = self.validate_ip(str(self.args.atak_ip))
         if self.args.atak_port:
-            ret &= self.validate_port(str(self.args.qgc_port))
+            ret &= self.validate_port(str(self.args.gcs_port))
         ret &= self.validate_port(str(self.args.atak_port))
         ret &= self.validate_bitrate(int(self.args.bitrate))
         ret &= self.is_json_file(str(self.args.config_file))
         ret &= self.validate_max_zoom(float(self.args.max_zoom))
+        ret &= self.validate_active_gcs(self.args.active_gcs)
         return ret
 
     def validate_ip(self, ip: str) -> bool:
@@ -53,6 +56,9 @@ class Validator:
             return False
         except ValueError:
             return False
+
+    def validate_active_gcs(self, active_gcs: str) -> bool:
+        return active_gcs.lower() in [GCSType.QGC.value, GCSType.ATAK.value]
 
     def is_json_file(str, file_name: str) -> bool:
         return os.path.isfile(file_name) and file_name.lower().endswith(".json")


### PR DESCRIPTION
* GCS ip and port will now work for either QGC (default) or ATAK.
* To change the active GCS, send command `active_gcs {qgc|atak}`.
* Variable renames
* Reordered/organized command order