### PR TITLE
Add support for ZeroMQ for commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ sudo apt install -y ffmpeg
 sudo apt install -y python3-opencv
 sudo apt install -y python3-numpy
 sudo apt install -y libzmq3-dev
-pip3 install pyzmq --break-system-packages
-
+sudo apt install -y python3-zmq
 ```
 ## GCS Selection
 pistreamer_v2 has the option to stream to QGroundControl as the GCS or ATAK. Generally speaking ATAK requires a MPEG-TS video format whereas GCS is a RDP stream. Since a pilot will only need one active GCS at a time, either `ffmpeg_command_mpeg_ts` or `ffmpeg_command_rtp` will be the active streaming protocol at a time.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ sudo apt install -y python3-picamera2
 sudo apt install -y ffmpeg
 sudo apt install -y python3-opencv
 sudo apt install -y python3-numpy
+sudo apt install -y libzmq3-dev
+pip3 install pyzmq --break-system-packages
+
 ```
 ## GCS Selection
 pistreamer_v2 has the option to stream to QGroundControl as the GCS or ATAK. Generally speaking ATAK requires a MPEG-TS video format whereas GCS is a RDP stream. Since a pilot will only need one active GCS at a time, either `ffmpeg_command_mpeg_ts` or `ffmpeg_command_rtp` will be the active streaming protocol at a time.

--- a/_command_tester.py
+++ b/_command_tester.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
-from constants import CMD_SOCKET_PORT, CMD_SOCKET_HOST, CommandType, MessageProtocolType
+from constants import CMD_SOCKET_PORT, CMD_SOCKET_HOST, CommandType, CommandProtocolType
 import time
 import socket
+import zmq
+
 
 if __name__ == "__main__":
 
@@ -18,11 +20,22 @@ if __name__ == "__main__":
         finally:
             client_socket.close()
 
+    def _send_data_zeromq(command_type: CommandType, command_value: str = "") -> None:
+        context = zmq.Context()
+        socket = context.socket(zmq.PAIR)
+        socket.bind(f"tcp://*:{CMD_SOCKET_PORT}")
+        data = f"{command_type.value} {command_value}".strip()
+        socket.send_string(data)
+
     def _send_data(command_type: CommandType, command_value: str = "") -> None:
-        # change this to control which protocol to use
-        protocol = MessageProtocolType.ZEROMQ.value
-        if protocol == MessageProtocolType.ZEROMQ.value:
-            pass
+        ### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ###  Change protocol as needed
+        protocol = CommandProtocolType.ZEROMQ.value
+        # protocol = MessageProtocolType.SOCKET.value
+        ### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+        if protocol == CommandProtocolType.ZEROMQ.value:
+            _send_data_zeromq(command_type, command_value)
         else:
             _send_data_socket(command_type, command_value)
 

--- a/_command_tester.py
+++ b/_command_tester.py
@@ -1,53 +1,69 @@
 #!/usr/bin/env python3
 
-from command_service import CommandService
-from constants import CMD_SOCKET_PORT, CMD_SOCKET_HOST, CommandType
+from constants import CMD_SOCKET_PORT, CMD_SOCKET_HOST, CommandType, MessageProtocolType
 import time
+import socket
 
+if __name__ == "__main__":
 
-def _send_data(command_type: CommandType, command_value: str = "") -> None:
-    data = f"{command_type.value} {command_value}".strip()
-    CommandService.send_data_out(data=data, host=CMD_SOCKET_HOST, port=CMD_SOCKET_PORT)
+    def _send_data_socket(command_type: CommandType, command_value: str = "") -> None:
+        data = f"{command_type.value} {command_value}".strip()
+        try:
+            _data = data.strip().encode()
+            client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            client_socket.connect((CMD_SOCKET_HOST, CMD_SOCKET_PORT))
+            client_socket.sendall(_data)
+        except Exception as e:
+            print(f"{CMD_SOCKET_HOST}:{CMD_SOCKET_PORT} {e}")
+        finally:
+            client_socket.close()
 
+    def _send_data(command_type: CommandType, command_value: str = "") -> None:
+        # change this to control which protocol to use
+        protocol = MessageProtocolType.ZEROMQ.value
+        if protocol == MessageProtocolType.ZEROMQ.value:
+            pass
+        else:
+            _send_data_socket(command_type, command_value)
 
-# Modify the command_type and command_value as needed=
+    # Modify the command_type and command_value as needed
 
-#######-####### BITRATE #######-#######
-_send_data(command_type=CommandType.BITRATE, command_value="2500")
+    #######-####### BITRATE #######-#######
+    # _send_data(command_type=CommandType.BITRATE, command_value="2500")
 
-#######-####### ZOOM #######-#######
-# _send_data(command_type=CommandType.ZOOM, command_value="4.0")
-# time.sleep(2)
-# _send_data(command_type=CommandType.ZOOM, command_value="3.0")
-# time.sleep(2)
-# _send_data(command_type=CommandType.ZOOM, command_value="2.0")
-# _send_data(command_type=CommandType.MAX_ZOOM, command_value="8.0")
-# _send_data(command_type=CommandType.ZOOM, command_value="in")
-# _send_data(command_type=CommandType.ZOOM, command_value="out")
-# time.sleep(2)
-# _send_data(command_type=CommandType.ZOOM, command_value="stop")
+    #######-####### ZOOM #######-#######
+    _send_data(command_type=CommandType.ZOOM, command_value="2.0")
+    # time.sleep(2)
+    # _send_data(command_type=CommandType.ZOOM, command_value="3.0")
+    # time.sleep(2)
+    # _send_data(command_type=CommandType.ZOOM, command_value="2.0")
+    # _send_data(command_type=CommandType.MAX_ZOOM, command_value="8.0")
+    # _send_data(command_type=CommandType.ZOOM, command_value="in")
+    # _send_data(command_type=CommandType.ZOOM, command_value="out")
+    # time.sleep(2)
+    # _send_data(command_type=CommandType.ZOOM, command_value="stop")
 
-#######-####### PHOTO #######-#######
-# _send_data(command_type=CommandType.TAKE_PHOTO)
+    #######-####### PHOTO #######-#######
+    # _send_data(command_type=CommandType.TAKE_PHOTO)
 
-#######-####### QGC #######-#######
-# _send_data(command_type=CommandType.GCS_IP, command_value="192.168.1.124")
-# _send_data(command_type=CommandType.GCS_PORT, command_value="5600")
-# _send_data(command_type=CommandType.GCS_HOST, command_value="192.168.1.124:5600")
-# _send_data(command_type=CommandType.START_GCS_STREAM)
-# _send_data(command_type=CommandType.STOP_GCS_STREAM)
-_send_data(command_type=CommandType.STREAMING_PROTOCOL, command_value="rtp")
+    #######-####### QGC #######-#######
+    # _send_data(command_type=CommandType.GCS_IP, command_value="192.168.1.124")
+    # _send_data(command_type=CommandType.GCS_PORT, command_value="5600")
+    # _send_data(command_type=CommandType.GCS_HOST, command_value="192.168.1.124:5600")
+    # _send_data(command_type=CommandType.START_GCS_STREAM)
+    # _send_data(command_type=CommandType.STOP_GCS_STREAM)
+    # _send_data(command_type=CommandType.STREAMING_PROTOCOL, command_value="rtp")
 
-#######-####### RECORD #######-#######
-# _send_data(command_type=CommandType.RECORD)
-# time.sleep(10)
-# _send_data(command_type=CommandType.STOP_RECORDING)
+    #######-####### RECORD #######-#######
+    # _send_data(command_type=CommandType.RECORD)
+    # time.sleep(10)
+    # _send_data(command_type=CommandType.STOP_RECORDING)
 
-#######-####### STABILIZE #######-#######
-# _send_data(command_type=CommandType.STABILIZE, command_value="start")
-# _send_data(
-#     command_type=CommandType.STABILIZE, command_value="stop"
-# )
+    #######-####### STABILIZE #######-#######
+    # _send_data(command_type=CommandType.STABILIZE, command_value="start")
+    # _send_data(
+    #     command_type=CommandType.STABILIZE, command_value="stop"
+    # )
 
-#######-####### TRACKING #######-#######
-# _send_data(command_type=CommandType.INIT_TRACKING_POI, command_value="560,290")
+    #######-####### TRACKING #######-#######
+    # _send_data(command_type=CommandType.INIT_TRACKING_POI, command_value="560,290")

--- a/command_controller.py
+++ b/command_controller.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 
 from time import time
-from typing import Literal, Optional, Union
-from command_service import CommandService
+from typing import Union
 from constants import (
     MIN_ZOOM,
     ZOOM_RATE,
@@ -253,10 +252,9 @@ class CommandController:
         # Set the updated ScalerCrop for the second stream
         self.pi_streamer.picam2.set_controls({"ScalerCrop": new_crop})
 
-        CommandService.send_data_out(
+        self.pi_streamer.command_service.send_data_out(
             data=f"{OutputCommandType.ZOOM_LEVEL.value} {self.current_zoom}",
-            host=OUTPUT_SOCKET_HOST,
-            port=OUTPUT_SOCKET_PORT,
+            destination_kwargs={"host": OUTPUT_SOCKET_HOST, "port": OUTPUT_SOCKET_PORT},
         )
 
         if self.pi_streamer.verbose:

--- a/command_controller.py
+++ b/command_controller.py
@@ -9,8 +9,6 @@ from constants import (
     StreamingProtocolType,
     OutputCommandType,
     ZoomStatus,
-    OUTPUT_SOCKET_PORT,
-    OUTPUT_SOCKET_HOST,
     TrackStatus,
 )
 from validator import Validator
@@ -253,8 +251,7 @@ class CommandController:
         self.pi_streamer.picam2.set_controls({"ScalerCrop": new_crop})
 
         self.pi_streamer.command_service.send_data_out(
-            data=f"{OutputCommandType.ZOOM_LEVEL.value} {self.current_zoom}",
-            destination_kwargs={"host": OUTPUT_SOCKET_HOST, "port": OUTPUT_SOCKET_PORT},
+            data=f"{OutputCommandType.ZOOM_LEVEL.value} {self.current_zoom}"
         )
 
         if self.pi_streamer.verbose:

--- a/command_service.py
+++ b/command_service.py
@@ -1,104 +1,17 @@
 #!/usr/bin/env python3
 
-from typing import Any, Tuple, List
-from constants import CMD_SOCKET_HOST, CMD_SOCKET_PORT, MAX_SOCKET_CONNECTIONS
-import socket
-import select
+from typing import Tuple, List
 
 """
-Commands are communicated to the pistreamer app via a dedicated socket host:port and
-status and other data is returned back to the mavlink service at a different port.
+Commands are communicated to the pistreamer app through either through a dedicated socket host:port
+or a similar process called ZeroMQ. Status and other data is returned back to the mavlink service
+through the same protocol but a different connection.
 """
 
 
 class CommandService:
-    def __init__(self):
-        # Create the server socket
-        self.server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self.server_socket.bind((CMD_SOCKET_HOST, CMD_SOCKET_PORT))
-        self.server_socket.listen(MAX_SOCKET_CONNECTIONS)
-
-        print(
-            f"{__name__} listening for data on socket {CMD_SOCKET_HOST}:{CMD_SOCKET_PORT}"
-        )
-        self.server_socket.setblocking(False)
-
-        # Accept a single client connection (blocking until a connection is made)
-        self.client_socket, self.client_address = None, None
-
-    def _accept_client(self):
-        try:
-            ready_to_read, _, _ = select.select(
-                [self.server_socket], [], [], 0
-            )  # don't wait
-            if ready_to_read:
-                self.client_socket, self.client_address = self.server_socket.accept()
-                self.client_socket.setblocking(
-                    False
-                )  # Set the client socket to non-blocking mode
-                print(f"Accepted connection from {self.client_address}")
-        except BlockingIOError:
-            # No incoming connections, handle this case as needed
-            pass
-
-    def _read_socket(self) -> str:
-        self._accept_client()
-        if self.client_socket:
-            ready_to_read, _, _ = select.select(
-                [self.client_socket], [], [], 0
-            )  # don't wait
-            if ready_to_read:
-                try:
-                    # Try to receive data from the client
-                    data = self.client_socket.recv(1024)
-                    if data:
-                        return data.decode()
-                except Exception as e:
-                    if e:
-                        print(e)
-        return ""
-
-    @staticmethod
-    def send_data_out(data: str, host: str, port: int) -> None:
-        """
-        Used to send data out over another host:port client socket connection.
-        """
-        try:
-            _data = data.strip().encode()
-            client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            client_socket.connect((host, port))
-            client_socket.sendall(_data)
-        except Exception as e:
-            print(f"{host}:{port} {e}")
-        finally:
-            client_socket.close()
+    def send_data_out(self, data: str, destination_kwargs: dict) -> None:
+        raise NotImplementedError()
 
     def get_pending_commands(self) -> List[Tuple[str, str]]:
-        """
-        Returns the a list of command that has not been read yet from the socket.
-        The first param in the tuple is the command type followed by the command value.
-        If no commands are ready, then an empty list is returned.
-        """
-        commands = []
-        try:
-            # Try reading from the socket
-            data = self._read_socket()
-            if data:
-                decoded_data = str(data).split("\n")
-                decoded_data = [str(item).strip() for item in decoded_data if item]
-                print(f"Received {len(decoded_data)} total command(s): {decoded_data}")
-                for command in decoded_data:
-                    command_details = command.strip().split(" ")
-                    commands.append(
-                        (
-                            command_details[0].strip(),
-                            command_details[1].strip()
-                            if len(command_details) > 1
-                            else "",
-                        )
-                    )
-        except Exception as e:
-            print(e)
-
-        return commands
+        raise NotImplementedError()

--- a/command_service.py
+++ b/command_service.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from typing import Tuple, List
+from typing import Optional, Tuple, List, Any
 
 """
 Commands are communicated to the pistreamer app through either through a dedicated socket host:port
@@ -10,6 +10,25 @@ through the same protocol but a different connection.
 
 
 class CommandService:
+    def _get_commands_from_data(self, data: str) -> List[Any]:
+        commands: List[Any] = []
+
+        if not data:
+            return commands
+
+        decoded_data = str(data).split("\n")
+        decoded_data = [str(item).strip() for item in decoded_data if item]
+        print(f"Received {len(decoded_data)} total command(s): {decoded_data}")
+        for command in decoded_data:
+            command_details = command.strip().split(" ")
+            commands.append(
+                (
+                    command_details[0].strip(),
+                    command_details[1].strip() if len(command_details) > 1 else "",
+                )
+            )
+        return commands
+
     def send_data_out(self, data: str, destination_kwargs: dict) -> None:
         raise NotImplementedError()
 

--- a/command_service.py
+++ b/command_service.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from typing import Optional, Tuple, List, Any
+from typing import Tuple, List, Any
 
 """
 Commands are communicated to the pistreamer app through either through a dedicated socket host:port
@@ -29,7 +29,7 @@ class CommandService:
             )
         return commands
 
-    def send_data_out(self, data: str, destination_kwargs: dict) -> None:
+    def send_data_out(self, data: str) -> None:
         raise NotImplementedError()
 
     def get_pending_commands(self) -> List[Tuple[str, str]]:

--- a/constants.py
+++ b/constants.py
@@ -65,5 +65,19 @@ class TrackStatus(Enum):
 
 
 class StreamingProtocolType(Enum):
+    """
+    The format in which the camera feed is streamed via a ffmpeg process
+    """
+
     RTP = "rtp"  # Used for QGroundControl
     MPEG_TS = "mpegts"  # Used for Android (Tactical Assault/Team Awareness) Kit
+
+
+class MessageProtocolType(Enum):
+    """
+    The mechanism in which commands and mavlink data are sent to the pistreamer and how
+    the pistreamer sends output data back to listening processes.
+    """
+
+    SOCKET = "socket"
+    ZEROMQ = "zeromq"

--- a/constants.py
+++ b/constants.py
@@ -73,7 +73,7 @@ class StreamingProtocolType(Enum):
     MPEG_TS = "mpegts"  # Used for Android (Tactical Assault/Team Awareness) Kit
 
 
-class MessageProtocolType(Enum):
+class CommandProtocolType(Enum):
     """
     The mechanism in which commands and mavlink data are sent to the pistreamer and how
     the pistreamer sends output data back to listening processes.

--- a/pistreamer_v2.py
+++ b/pistreamer_v2.py
@@ -25,7 +25,7 @@ from constants import (
     MIN_ZOOM,
     STREAMING_FRAMESIZE,
     STILL_FRAMESIZE,
-    MessageProtocolType,
+    CommandProtocolType,
     StreamingProtocolType,
     TrackStatus,
     ZoomStatus,
@@ -49,17 +49,17 @@ class PiStreamer2:
         verbose: bool = False,
         max_zoom: float = DEFAULT_MAX_ZOOM,
         streaming_protocol: str = StreamingProtocolType.RTP.value,
-        message_protocol: str = MessageProtocolType.ZEROMQ.value,
+        command_protocol: str = CommandProtocolType.ZEROMQ.value,
     ) -> None:
         # utilities
         from command_controller import CommandController
 
         self.command_controller: CommandController = None  # type: ignore # this is set later in _set_command_controller
 
-        if message_protocol == MessageProtocolType.ZEROMQ.value:
-            self.command_service: SocketService = SocketService()
-        elif message_protocol == MessageProtocolType.SOCKET.value:
-            self.command_service: ZeroMQService = ZeroMQService()  # type: ignore
+        if command_protocol == CommandProtocolType.ZEROMQ.value:
+            self.command_service: ZeroMQService = ZeroMQService()
+        elif command_protocol == CommandProtocolType.SOCKET.value:
+            self.command_service: SocketService = SocketService()  # type: ignore
         else:
             raise NotImplementedError(
                 "Only ZEROMQ and SOCKET message protocols are supported"
@@ -502,6 +502,12 @@ if __name__ == "__main__":
         default=StreamingProtocolType.RTP.value,
         help="Streaming protocol to use (RTP or MPEGTS)",
     )
+    parser.add_argument(
+        "--command_protocol",
+        type=str,
+        default=CommandProtocolType.ZEROMQ.value,
+        help="Command protocol to use for messages (socket or zeromq)",
+    )
     args = parser.parse_args()
     try:
         Validator(args)
@@ -518,6 +524,7 @@ if __name__ == "__main__":
         verbose=args.verbose,
         max_zoom=args.max_zoom,
         streaming_protocol=args.streaming_protocol,
+        command_protocol=args.command_protocol,
     )
     from command_controller import CommandController
 

--- a/pistreamer_v2.py
+++ b/pistreamer_v2.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from typing import Any, Optional
-from command_service import CommandService
 from ffmpeg_configs import (
     get_ffmpeg_command_mpeg_ts,
     get_ffmpeg_command_record,
@@ -26,13 +25,16 @@ from constants import (
     MIN_ZOOM,
     STREAMING_FRAMESIZE,
     STILL_FRAMESIZE,
+    MessageProtocolType,
     StreamingProtocolType,
     TrackStatus,
     ZoomStatus,
 )
 from object_tracker import ObjectTracker
 from cam_utils import get_timestamp
+from socket_service import SocketService
 from validator import Validator
+from zeromq_service import ZeroMQService
 
 
 class PiStreamer2:
@@ -47,12 +49,22 @@ class PiStreamer2:
         verbose: bool = False,
         max_zoom: float = DEFAULT_MAX_ZOOM,
         streaming_protocol: str = StreamingProtocolType.RTP.value,
+        message_protocol: str = MessageProtocolType.ZEROMQ.value,
     ) -> None:
         # utilities
         from command_controller import CommandController
 
         self.command_controller: CommandController = None  # type: ignore # this is set later in _set_command_controller
-        self.command_service: CommandService = CommandService()
+
+        if message_protocol == MessageProtocolType.ZEROMQ.value:
+            self.command_service: SocketService = SocketService()
+        elif message_protocol == MessageProtocolType.SOCKET.value:
+            self.command_service: ZeroMQService = ZeroMQService()  # type: ignore
+        else:
+            raise NotImplementedError(
+                "Only ZEROMQ and SOCKET message protocols are supported"
+            )
+
         self.pid = 0
         self.verbose = verbose
         self.streaming_protocol = streaming_protocol

--- a/socket_service.py
+++ b/socket_service.py
@@ -2,7 +2,13 @@
 
 from typing import Tuple, List
 from command_service import CommandService
-from constants import CMD_SOCKET_HOST, CMD_SOCKET_PORT, MAX_SOCKET_CONNECTIONS
+from constants import (
+    CMD_SOCKET_HOST,
+    CMD_SOCKET_PORT,
+    MAX_SOCKET_CONNECTIONS,
+    OUTPUT_SOCKET_HOST,
+    OUTPUT_SOCKET_PORT,
+)
 import socket
 import select
 
@@ -60,19 +66,17 @@ class SocketService(CommandService):
                         print(e)
         return ""
 
-    def send_data_out(self, data: str, destination_kwargs: dict) -> None:
+    def send_data_out(self, data: str) -> None:
         """
         Used to send data out over another host:port client socket connection.
         """
         try:
-            host = destination_kwargs.get("host")
-            port = destination_kwargs.get("port")
             _data = data.strip().encode()
             client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            client_socket.connect((host, port))
+            client_socket.connect((OUTPUT_SOCKET_HOST, OUTPUT_SOCKET_PORT))
             client_socket.sendall(_data)
         except Exception as e:
-            print(f"{host}:{port} {e}")
+            print(f"{OUTPUT_SOCKET_HOST}:{OUTPUT_SOCKET_PORT} {e}")
         finally:
             client_socket.close()
 

--- a/socket_service.py
+++ b/socket_service.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+from typing import Tuple, List
+from command_service import CommandService
+from constants import CMD_SOCKET_HOST, CMD_SOCKET_PORT, MAX_SOCKET_CONNECTIONS
+import socket
+import select
+
+"""
+Commands are communicated to the pistreamer app via a dedicated socket host:port and
+status and other data is returned back to the mavlink service at a different port.
+"""
+
+
+class SocketService(CommandService):
+    def __init__(self):
+        # Create the server socket
+        self.server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.server_socket.bind((CMD_SOCKET_HOST, CMD_SOCKET_PORT))
+        self.server_socket.listen(MAX_SOCKET_CONNECTIONS)
+
+        print(
+            f"{__name__} listening for data on socket {CMD_SOCKET_HOST}:{CMD_SOCKET_PORT}"
+        )
+        self.server_socket.setblocking(False)
+
+        # Accept a single client connection (blocking until a connection is made)
+        self.client_socket, self.client_address = None, None
+
+    def _accept_client(self):
+        try:
+            ready_to_read, _, _ = select.select(
+                [self.server_socket], [], [], 0
+            )  # don't wait
+            if ready_to_read:
+                self.client_socket, self.client_address = self.server_socket.accept()
+                self.client_socket.setblocking(
+                    False
+                )  # Set the client socket to non-blocking mode
+                print(f"Accepted connection from {self.client_address}")
+        except BlockingIOError:
+            # No incoming connections, handle this case as needed
+            pass
+
+    def _read_socket(self) -> str:
+        self._accept_client()
+        if self.client_socket:
+            ready_to_read, _, _ = select.select(
+                [self.client_socket], [], [], 0
+            )  # don't wait
+            if ready_to_read:
+                try:
+                    # Try to receive data from the client
+                    data = self.client_socket.recv(1024)
+                    if data:
+                        return data.decode()
+                except Exception as e:
+                    if e:
+                        print(e)
+        return ""
+
+    def send_data_out(self, data: str, destination_kwargs: dict) -> None:
+        """
+        Used to send data out over another host:port client socket connection.
+        """
+        try:
+            host = destination_kwargs.get("host")
+            port = destination_kwargs.get("port")
+            _data = data.strip().encode()
+            client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            client_socket.connect((host, port))
+            client_socket.sendall(_data)
+        except Exception as e:
+            print(f"{host}:{port} {e}")
+        finally:
+            client_socket.close()
+
+    def get_pending_commands(self) -> List[Tuple[str, str]]:
+        """
+        Returns the a list of command that has not been read yet from the socket.
+        The first param in the tuple is the command type followed by the command value.
+        If no commands are ready, then an empty list is returned.
+        """
+        commands = []
+        try:
+            # Try reading from the socket
+            data = self._read_socket()
+            if data:
+                decoded_data = str(data).split("\n")
+                decoded_data = [str(item).strip() for item in decoded_data if item]
+                print(f"Received {len(decoded_data)} total command(s): {decoded_data}")
+                for command in decoded_data:
+                    command_details = command.strip().split(" ")
+                    commands.append(
+                        (
+                            command_details[0].strip(),
+                            command_details[1].strip()
+                            if len(command_details) > 1
+                            else "",
+                        )
+                    )
+        except Exception as e:
+            print(e)
+
+        return commands

--- a/socket_service.py
+++ b/socket_service.py
@@ -82,25 +82,11 @@ class SocketService(CommandService):
         The first param in the tuple is the command type followed by the command value.
         If no commands are ready, then an empty list is returned.
         """
-        commands = []
         try:
             # Try reading from the socket
             data = self._read_socket()
-            if data:
-                decoded_data = str(data).split("\n")
-                decoded_data = [str(item).strip() for item in decoded_data if item]
-                print(f"Received {len(decoded_data)} total command(s): {decoded_data}")
-                for command in decoded_data:
-                    command_details = command.strip().split(" ")
-                    commands.append(
-                        (
-                            command_details[0].strip(),
-                            command_details[1].strip()
-                            if len(command_details) > 1
-                            else "",
-                        )
-                    )
+            return self._get_commands_from_data(data)
         except Exception as e:
             print(e)
 
-        return commands
+        return []

--- a/validator.py
+++ b/validator.py
@@ -2,7 +2,7 @@ import os
 import ipaddress
 from typing import Any, Optional
 
-from constants import StreamingProtocolType
+from constants import CommandProtocolType, StreamingProtocolType
 
 
 class Validator:
@@ -20,6 +20,7 @@ class Validator:
         ret &= self.is_json_file(str(self.args.config_file))
         ret &= self.validate_max_zoom(float(self.args.max_zoom))
         ret &= self.validate_streaming_protocol(self.args.streaming_protocol)
+        ret &= self.validate_command_protocol(self.args.command_protocol)
         return ret
 
     def validate_ip(self, ip: str) -> bool:
@@ -57,6 +58,12 @@ class Validator:
         return streaming_protocol.lower() in [
             StreamingProtocolType.RTP.value,
             StreamingProtocolType.MPEG_TS.value,
+        ]
+
+    def validate_command_protocol(self, command_protocol: str) -> bool:
+        return command_protocol.lower() in [
+            CommandProtocolType.SOCKET.value,
+            CommandProtocolType.ZEROMQ.value,
         ]
 
     def is_json_file(str, file_name: str) -> bool:

--- a/zeromq_service.py
+++ b/zeromq_service.py
@@ -12,6 +12,8 @@ import zmq
 """
 Commands are communicated to the pistreamer app via a dedicated socket host:port and
 status and other data is returned back to the mavlink service at a different port.
+
+Unlike the socket_service.py, this service uses ZeroMQ for communication: https://zeromq.org/
 """
 
 

--- a/zeromq_service.py
+++ b/zeromq_service.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+from typing import Tuple, List
+from command_service import CommandService
+from constants import CMD_SOCKET_HOST, CMD_SOCKET_PORT, MAX_SOCKET_CONNECTIONS
+import socket
+import select
+
+"""
+Commands are communicated to the pistreamer app via a dedicated socket host:port and
+status and other data is returned back to the mavlink service at a different port.
+"""
+
+
+class ZeroMQService(CommandService):
+    def __init__(self):
+        # Create the server socket
+        self.server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.server_socket.bind((CMD_SOCKET_HOST, CMD_SOCKET_PORT))
+        self.server_socket.listen(MAX_SOCKET_CONNECTIONS)
+
+        print(
+            f"{__name__} listening for data on socket {CMD_SOCKET_HOST}:{CMD_SOCKET_PORT}"
+        )
+        self.server_socket.setblocking(False)
+
+        # Accept a single client connection (blocking until a connection is made)
+        self.client_socket, self.client_address = None, None
+
+    def _accept_client(self):
+        try:
+            ready_to_read, _, _ = select.select(
+                [self.server_socket], [], [], 0
+            )  # don't wait
+            if ready_to_read:
+                self.client_socket, self.client_address = self.server_socket.accept()
+                self.client_socket.setblocking(
+                    False
+                )  # Set the client socket to non-blocking mode
+                print(f"Accepted connection from {self.client_address}")
+        except BlockingIOError:
+            # No incoming connections, handle this case as needed
+            pass
+
+    def _read_socket(self) -> str:
+        self._accept_client()
+        if self.client_socket:
+            ready_to_read, _, _ = select.select(
+                [self.client_socket], [], [], 0
+            )  # don't wait
+            if ready_to_read:
+                try:
+                    # Try to receive data from the client
+                    data = self.client_socket.recv(1024)
+                    if data:
+                        return data.decode()
+                except Exception as e:
+                    if e:
+                        print(e)
+        return ""
+
+    def send_data_out(self, data: str, destination_kwargs: dict) -> None:
+        """
+        Used to send data out over another host:port client socket connection.
+        """
+        try:
+            host = destination_kwargs.get("host")
+            port = destination_kwargs.get("port")
+            _data = data.strip().encode()
+            client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            client_socket.connect((host, port))
+            client_socket.sendall(_data)
+        except Exception as e:
+            print(f"{host}:{port} {e}")
+        finally:
+            client_socket.close()
+
+    def get_pending_commands(self) -> List[Tuple[str, str]]:
+        """
+        Returns the a list of command that has not been read yet from the socket.
+        The first param in the tuple is the command type followed by the command value.
+        If no commands are ready, then an empty list is returned.
+        """
+        commands = []
+        try:
+            # Try reading from the socket
+            data = self._read_socket()
+            if data:
+                decoded_data = str(data).split("\n")
+                decoded_data = [str(item).strip() for item in decoded_data if item]
+                print(f"Received {len(decoded_data)} total command(s): {decoded_data}")
+                for command in decoded_data:
+                    command_details = command.strip().split(" ")
+                    commands.append(
+                        (
+                            command_details[0].strip(),
+                            command_details[1].strip()
+                            if len(command_details) > 1
+                            else "",
+                        )
+                    )
+        except Exception as e:
+            print(e)
+
+        return commands

--- a/zeromq_service.py
+++ b/zeromq_service.py
@@ -2,7 +2,10 @@
 
 from typing import Tuple, List
 from command_service import CommandService
-from constants import CMD_SOCKET_HOST, CMD_SOCKET_PORT, MAX_SOCKET_CONNECTIONS
+from constants import (
+    CMD_SOCKET_PORT,
+    OUTPUT_SOCKET_PORT,
+)
 import zmq
 
 
@@ -14,22 +17,35 @@ status and other data is returned back to the mavlink service at a different por
 
 class ZeroMQService(CommandService):
     def __init__(self):
-        self.context = zmq.Context()
-        self.socket = self.context.socket(zmq.PAIR)
-        self.socket.connect(f"tcp://localhost:{CMD_SOCKET_PORT}")
-        self.socket.setsockopt(
+        # Used for receiving commands
+        self.receive_context = zmq.Context()
+        self.receive_socket = self.receive_context.socket(zmq.PAIR)
+        self.receive_socket.connect(f"tcp://localhost:{CMD_SOCKET_PORT}")
+        self.receive_socket.setsockopt(
             zmq.SNDHWM, 1000
         )  # limit sender high water mark queue size to 1000 messages
-        self.socket.setsockopt(
+        self.receive_socket.setsockopt(
             zmq.RCVHWM, 1000
         )  # limit receiver high water mark queue size to 1000 messages
 
-    def send_data_out(self, data: str, destination_kwargs: dict) -> None:
-        pass
+        # Used for sending commands
+        self.send_context = zmq.Context()
+        self.send_socket = self.send_context.socket(zmq.PAIR)
+        self.send_socket.bind(
+            f"tcp://*:{OUTPUT_SOCKET_PORT}"
+        )  # notice we are binding here
+
+        self.send_socket = self.receive_context.socket(zmq.PAIR)
+        self.send_socket.connect(f"tcp://localhost:{CMD_SOCKET_PORT}")
+        self.send_socket.setsockopt(zmq.SNDHWM, 1000)
+        self.send_socket.setsockopt(zmq.RCVHWM, 1000)
+
+    def send_data_out(self, data: str) -> None:
+        self.send_socket.send_string(data)
 
     def get_pending_commands(self) -> List[Tuple[str, str]]:
         try:
-            data = self.socket.recv_string(zmq.NOBLOCK)
+            data = self.receive_socket.recv_string(zmq.NOBLOCK)
             return self._get_commands_from_data(data)
         except zmq.Again:
             # No message available, continue processing

--- a/zeromq_service.py
+++ b/zeromq_service.py
@@ -3,8 +3,8 @@
 from typing import Tuple, List
 from command_service import CommandService
 from constants import CMD_SOCKET_HOST, CMD_SOCKET_PORT, MAX_SOCKET_CONNECTIONS
-import socket
-import select
+import zmq
+
 
 """
 Commands are communicated to the pistreamer app via a dedicated socket host:port and
@@ -14,93 +14,24 @@ status and other data is returned back to the mavlink service at a different por
 
 class ZeroMQService(CommandService):
     def __init__(self):
-        # Create the server socket
-        self.server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self.server_socket.bind((CMD_SOCKET_HOST, CMD_SOCKET_PORT))
-        self.server_socket.listen(MAX_SOCKET_CONNECTIONS)
-
-        print(
-            f"{__name__} listening for data on socket {CMD_SOCKET_HOST}:{CMD_SOCKET_PORT}"
-        )
-        self.server_socket.setblocking(False)
-
-        # Accept a single client connection (blocking until a connection is made)
-        self.client_socket, self.client_address = None, None
-
-    def _accept_client(self):
-        try:
-            ready_to_read, _, _ = select.select(
-                [self.server_socket], [], [], 0
-            )  # don't wait
-            if ready_to_read:
-                self.client_socket, self.client_address = self.server_socket.accept()
-                self.client_socket.setblocking(
-                    False
-                )  # Set the client socket to non-blocking mode
-                print(f"Accepted connection from {self.client_address}")
-        except BlockingIOError:
-            # No incoming connections, handle this case as needed
-            pass
-
-    def _read_socket(self) -> str:
-        self._accept_client()
-        if self.client_socket:
-            ready_to_read, _, _ = select.select(
-                [self.client_socket], [], [], 0
-            )  # don't wait
-            if ready_to_read:
-                try:
-                    # Try to receive data from the client
-                    data = self.client_socket.recv(1024)
-                    if data:
-                        return data.decode()
-                except Exception as e:
-                    if e:
-                        print(e)
-        return ""
+        self.context = zmq.Context()
+        self.socket = self.context.socket(zmq.PAIR)
+        self.socket.connect(f"tcp://localhost:{CMD_SOCKET_PORT}")
+        self.socket.setsockopt(
+            zmq.SNDHWM, 1000
+        )  # limit sender high water mark queue size to 1000 messages
+        self.socket.setsockopt(
+            zmq.RCVHWM, 1000
+        )  # limit receiver high water mark queue size to 1000 messages
 
     def send_data_out(self, data: str, destination_kwargs: dict) -> None:
-        """
-        Used to send data out over another host:port client socket connection.
-        """
-        try:
-            host = destination_kwargs.get("host")
-            port = destination_kwargs.get("port")
-            _data = data.strip().encode()
-            client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            client_socket.connect((host, port))
-            client_socket.sendall(_data)
-        except Exception as e:
-            print(f"{host}:{port} {e}")
-        finally:
-            client_socket.close()
+        pass
 
     def get_pending_commands(self) -> List[Tuple[str, str]]:
-        """
-        Returns the a list of command that has not been read yet from the socket.
-        The first param in the tuple is the command type followed by the command value.
-        If no commands are ready, then an empty list is returned.
-        """
-        commands = []
         try:
-            # Try reading from the socket
-            data = self._read_socket()
-            if data:
-                decoded_data = str(data).split("\n")
-                decoded_data = [str(item).strip() for item in decoded_data if item]
-                print(f"Received {len(decoded_data)} total command(s): {decoded_data}")
-                for command in decoded_data:
-                    command_details = command.strip().split(" ")
-                    commands.append(
-                        (
-                            command_details[0].strip(),
-                            command_details[1].strip()
-                            if len(command_details) > 1
-                            else "",
-                        )
-                    )
-        except Exception as e:
-            print(e)
-
-        return commands
+            data = self.socket.recv_string(zmq.NOBLOCK)
+            return self._get_commands_from_data(data)
+        except zmq.Again:
+            # No message available, continue processing
+            pass
+        return []


### PR DESCRIPTION
* By default pistreamer_v2 will use zeromq but you can issue the command line arg `command_protocol={"socket"|"zeromq"}` to switch between that and our existing tcp socket. It cannot be changed midstream. 
* _command_tester can support either method but must be manually changed