### PR TITLE
EXIF service for saving metadata to photos

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ sudo apt install -y python3-opencv
 sudo apt install -y python3-numpy
 sudo apt install -y libzmq3-dev
 sudo apt install -y python3-zmq
+sudo apt install -y python3-piexif
 ```
 ## GCS Selection
 pistreamer_v2 has the option to stream to QGroundControl as the GCS or ATAK. Generally speaking ATAK requires a MPEG-TS video format whereas GCS is a RDP stream. Since a pilot will only need one active GCS at a time, either `ffmpeg_command_mpeg_ts` or `ffmpeg_command_rtp` will be the active streaming protocol at a time.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ sudo apt install -y python3-numpy
 sudo apt install -y libzmq3-dev
 sudo apt install -y python3-zmq
 sudo apt install -y python3-piexif
+sudo apt install -y python3-py3exiv2
 ```
 ## GCS Selection
 pistreamer_v2 has the option to stream to QGroundControl as the GCS or ATAK. Generally speaking ATAK requires a MPEG-TS video format whereas GCS is a RDP stream. Since a pilot will only need one active GCS at a time, either `ffmpeg_command_mpeg_ts` or `ffmpeg_command_rtp` will be the active streaming protocol at a time.

--- a/_command_tester.py
+++ b/_command_tester.py
@@ -37,11 +37,11 @@ if __name__ == "__main__":
 
         zeromq_socket.close()
 
-    def _send_data(commands: list[tuple]) -> None:
+    def _send_data(commands: List[Tuple[Any, Any]]) -> None:
         ### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         ###  Change protocol as needed
-        protocol = CommandProtocolType.ZEROMQ.value
-        # protocol = MessageProtocolType.SOCKET.value
+        # protocol = CommandProtocolType.ZEROMQ.value
+        protocol = CommandProtocolType.SOCKET.value
         ### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
         print(f"Sending {len(commands)} commands via {protocol}")

--- a/_command_tester.py
+++ b/_command_tester.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import json
 from typing import Any, List, Tuple
 from constants import CMD_SOCKET_PORT, CMD_SOCKET_HOST, CommandType, CommandProtocolType
 import time
@@ -40,8 +41,8 @@ if __name__ == "__main__":
     def _send_data(commands: List[Tuple[Any, Any]]) -> None:
         ### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         ###  Change protocol as needed
-        # protocol = CommandProtocolType.ZEROMQ.value
-        protocol = CommandProtocolType.SOCKET.value
+        protocol = CommandProtocolType.ZEROMQ.value
+        # protocol = CommandProtocolType.SOCKET.value
         ### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
         print(f"Sending {len(commands)} commands via {protocol}")
@@ -57,16 +58,50 @@ if __name__ == "__main__":
     # commands.append((CommandType.BITRATE,"2500"))
 
     #######-####### ZOOM #######-#######
-    commands.append((CommandType.ZOOM, "2.0"))
-    commands.append((CommandType.ZOOM, "3.5"))
+    # commands.append((CommandType.ZOOM, "2.0"))
     # commands.append((CommandType.MAX_ZOOM,"8.0"))
     # commands.append((CommandType.ZOOM,"in"))
     # commands.append((CommandType.ZOOM,"out"))
     # commands.append((CommandType.ZOOM,"stop"))
 
+    #######-####### EXIF/KLV #######-#######
+    commands.append(
+        (
+            CommandType.GPS_DATA,
+            json.dumps(
+                {
+                    "lat": 359686990,
+                    "lon": -839290440,
+                    "alt": 276,
+                    "eph": 1,
+                    "epv": 1,
+                    "vel": 0,
+                    "cog": 0,
+                    "fix_type": 2,
+                    "satellites_visible": 10,
+                    "time_usec": 1730920262680000,
+                }
+            ),
+        )
+    )
+
+    commands.append(
+        (
+            CommandType.MISC_DATA,
+            json.dumps(
+                {
+                    "pitch": 0.1,
+                    "roll": 0.02,
+                    "camera_model": "IMX477",
+                    "focal_length": (50, 1),
+                }
+            ),
+        )
+    )
+
     #######-####### PHOTO #######-#######
     commands.append((CommandType.TAKE_PHOTO, ""))
-    commands.append((CommandType.TAKE_PHOTO, ""))
+    # commands.append((CommandType.TAKE_PHOTO, ""))
 
     #######-####### QGC #######-#######
     # commands.append((CommandType.GCS_IP,"192.168.1.124"))

--- a/command_controller.py
+++ b/command_controller.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 
+import json
 from time import time
 from typing import Union
 from constants import (
     MIN_ZOOM,
     ZOOM_RATE,
     CommandType,
+    MavlinkGPSData,
+    MavlinkMiscData,
     StreamingProtocolType,
     OutputCommandType,
     ZoomStatus,
@@ -67,6 +70,18 @@ class CommandController:
                 x_center=int(x_center), y_center=int(y_center)
             )
             self.pi_streamer.track_status = TrackStatus.INIT.value
+        elif command_type == CommandType.GPS_DATA.value:
+            try:
+                self.pi_streamer.gps_data = MavlinkGPSData(**json.loads(command_value))
+            except Exception as e:
+                raise Exception(f"Invalid GPS data command : {e}")
+        elif command_type == CommandType.MISC_DATA.value:
+            try:
+                self.pi_streamer.misc_data = MavlinkMiscData(
+                    **json.loads(command_value)
+                )
+            except Exception as e:
+                raise Exception(f"Invalid GPS data command : {e}")
         elif command_type == CommandType.STABILIZE.value:
             try:
                 stab_value = (

--- a/command_controller.py
+++ b/command_controller.py
@@ -81,7 +81,7 @@ class CommandController:
                     **json.loads(command_value)
                 )
             except Exception as e:
-                raise Exception(f"Invalid GPS data command : {e}")
+                raise Exception(f"Invalid MISC data command : {e}")
         elif command_type == CommandType.STABILIZE.value:
             try:
                 stab_value = (

--- a/command_service.py
+++ b/command_service.py
@@ -18,13 +18,28 @@ class CommandService:
 
         decoded_data = str(data).split("\n")
         decoded_data = [str(item).strip() for item in decoded_data if item]
-        print(f"Received {len(decoded_data)} total command(s): {decoded_data}")
+
         for command in decoded_data:
-            command_details = command.strip().split(" ")
+            command = command.strip()
+            first_space_index = command.find(" ")
+
+            if first_space_index != -1:
+                command_type = command[
+                    :first_space_index
+                ].strip()  # Part before the first space
+                command_value = command[
+                    first_space_index + 1 :
+                ].strip()  # Rest of the string after the first space
+            else:
+                command_type = (
+                    command.strip()
+                )  # No space found, entire string is command_type
+                command_value = ""
+
             commands.append(
                 (
-                    command_details[0].strip(),
-                    command_details[1].strip() if len(command_details) > 1 else "",
+                    command_type,
+                    command_value,
                 )
             )
         return commands

--- a/constants.py
+++ b/constants.py
@@ -44,6 +44,10 @@ class CommandType(Enum):
     STABILIZE = "stabilize"
     INIT_TRACKING_POI = "init_tracking_poi"  # `init_tracking_poi x,y` is an example
     STOP_TRACKING = "stop_tracking"
+    GPS_DATA = (
+        "gps_data"  # `gps_data "json encoded string of MavlinkGPSData"` is an example
+    )
+    MISC_DATA = "misc_data"  # `misc_data "json encoded string of MavlinkMiscData"` is an example
 
 
 class OutputCommandType(Enum):

--- a/constants.py
+++ b/constants.py
@@ -44,10 +44,8 @@ class CommandType(Enum):
     STABILIZE = "stabilize"
     INIT_TRACKING_POI = "init_tracking_poi"  # `init_tracking_poi x,y` is an example
     STOP_TRACKING = "stop_tracking"
-    GPS_DATA = (
-        "gps_data"  # `gps_data "json encoded string of MavlinkGPSData"` is an example
-    )
-    MISC_DATA = "misc_data"  # `misc_data "json encoded string of MavlinkMiscData"` is an example
+    GPS_DATA = "gps_data"  # `gps_data '{"lat": 359686990, "lon": -839290440, "alt": 276, "eph": 1, "epv": 1, "vel": 0, "cog": 0, "fix_type": 2, "satellites_visible": 10, "time_usec": 1730920262680000}'` is an example
+    MISC_DATA = "misc_data"  # `misc_data '{"pitch": 0.1, "roll": 0.02, "camera_model": "IMX477", "focal_length": [50, 1]}'` is an example
 
 
 class OutputCommandType(Enum):

--- a/constants.py
+++ b/constants.py
@@ -1,4 +1,4 @@
-from typing import Final, Tuple, Union
+from typing import Final, Tuple
 from enum import Enum
 from dataclasses import dataclass
 
@@ -85,12 +85,32 @@ class CommandProtocolType(Enum):
 
 
 @dataclass
-class ExifDataGPS:
-    GPSLatitude: str
-    GPSLatitudeRef: str
-    GPSLongitude: str
-    GPSLongitudeRef: str
-    GPSAltitude: Union[int, float]
-    GPSAltitudeRef: int  # 0 = above sea level, 1 = below
-    GPSDateStamp: str  # format `2024:11:05``
-    GPSTimeStamp: Tuple[Tuple[int, int], Tuple[int, int], Tuple[int, int]]
+class MavlinkGPSData:
+    """
+    Defines the fields coming from a MAVLink GPS_RAW_INT messages for both EXIF and KLV data.
+    Note, EXIF doesn't support all of these fields but KLV and XMP can.
+    See https://data.pix4d.com/misc/KB/documents/Exif_tags_for_project_creation-Pix4D_products.pdf
+    """
+
+    lat: int = 0  # Latitude in 1e-7 degrees, e.g., 37.4243276° N = 374243276
+    lon: int = 0  # Longitude in 1e-7 degrees, e.g., -122.071482° W = -122071482
+    alt: int = 0  # Altitude in millimeters above mean sea level
+    eph: int = 0  # GPS HDOP horizontal dilution of position in cm (higher is worse)
+    epv: int = 0  # GPS VDOP vertical dilution of position in cm (higher is worse)
+    vel: int = 0  # GPS ground speed in cm/s
+    cog: int = 0  # Course over ground (heading) in centi-degrees
+    fix_type: int = 0  # GPS fix type, e.g., 0: no fix, 1: 2D fix, 2: 3D fix
+    satellites_visible: int = 0  # Number of visible satellites
+    time_usec: int = 0  # Timestamp (microseconds since UNIX epoch)
+
+
+@dataclass
+class MavlinkMiscData:
+    """
+    Defines the fields coming from MAVLink camera/position messages for both EXIF and KLV data.
+    """
+
+    pitch: float = 0.0  # Timestamp in milliseconds since system boot
+    roll: float = 0.0  # Latitude in 1e-7 degrees, e.g., 37.4243276° N = 374243276
+    camera_model: str = "Unknown"  # IMX477
+    focal_length: Tuple[int, int] = (0, 0)  # (50, 1) for 50mm

--- a/constants.py
+++ b/constants.py
@@ -17,6 +17,8 @@ OUTPUT_SOCKET_PORT = 54322
 MAX_SOCKET_CONNECTIONS = 3
 INIT_BBOX_COLOR = (128, 128, 128)  # Grey color in BGR
 ACTIVE_BBOX_COLOR = (0, 0, 255)  # Red color in BGR
+NAMESPACE_URI = "http://pix4d.com/camera/1.0/"
+NAMESPACE_PREFIX = "Camera"
 
 
 class CommandType(Enum):
@@ -107,10 +109,12 @@ class MavlinkGPSData:
 @dataclass
 class MavlinkMiscData:
     """
-    Defines the fields coming from MAVLink camera/position messages for both EXIF and KLV data.
+    Defines the fields coming from MAVLink camera/position like ATTITUDE messages for both EXIF and KLV data.
     """
 
-    pitch: float = 0.0  # Timestamp in milliseconds since system boot
-    roll: float = 0.0  # Latitude in 1e-7 degrees, e.g., 37.4243276° N = 374243276
-    camera_model: str = "Unknown"  # IMX477
-    focal_length: Tuple[int, int] = (0, 0)  # (50, 1) for 50mm
+    pitch: float = 0.0  # radians (positive is up, negative is down)
+    roll: float = (
+        0.0  # radians (positive is right side down, negative is left side down)
+    )
+    camera_model: str = "Unknown"  # i.e. IMX477
+    focal_length: Tuple[int, int] = (0, 0)  # i.e (50, 1) for 50mm

--- a/constants.py
+++ b/constants.py
@@ -1,5 +1,6 @@
-from typing import Final
+from typing import Final, Tuple, Union
 from enum import Enum
+from dataclasses import dataclass
 
 FRAMERATE: Final = 30
 MIN_ZOOM: Final = 1.0
@@ -81,3 +82,15 @@ class CommandProtocolType(Enum):
 
     SOCKET = "socket"
     ZEROMQ = "zeromq"
+
+
+@dataclass
+class ExifDataGPS:
+    GPSLatitude: str
+    GPSLatitudeRef: str
+    GPSLongitude: str
+    GPSLongitudeRef: str
+    GPSAltitude: Union[int, float]
+    GPSAltitudeRef: int  # 0 = above sea level, 1 = below
+    GPSDateStamp: str  # format `2024:11:05``
+    GPSTimeStamp: Tuple[Tuple[int, int], Tuple[int, int], Tuple[int, int]]

--- a/exif_service.py
+++ b/exif_service.py
@@ -27,8 +27,8 @@ class EXIFService:
         decimal_degrees = gps_coord / 1e7
 
         # Extract degrees, minutes, and seconds
-        degrees = int(decimal_degrees)
-        minutes_decimal = (decimal_degrees - degrees) * 60
+        degrees = abs(int(decimal_degrees))  # Use absolute value for degrees
+        minutes_decimal = (abs(decimal_degrees) - degrees) * 60
         minutes = int(minutes_decimal)
         seconds = (minutes_decimal - minutes) * 60
 

--- a/exif_service.py
+++ b/exif_service.py
@@ -1,48 +1,126 @@
-from typing import Tuple, Union
-from constants import ExifDataGPS
+from datetime import datetime, timezone
+from typing import Tuple
+from constants import MavlinkGPSData, MavlinkMiscData
 import piexif
 from PIL import Image
+import pyexiv2
 
 
 class EXIFService:
-    def __init__(self, gps_data: ExifDataGPS, file_name: str):
+    def __init__(
+        self, gps_data: MavlinkGPSData, misc_data: MavlinkMiscData, file_name: str
+    ):
         self.gps_data = gps_data
+        self.misc_data = misc_data
         self.file_name = file_name
+        _now = datetime.now()
+        self.current_datetime = _now.strftime("%Y:%m:%d %H:%M:%S")
+        self.current_datetime_ms = int(_now.timestamp() * 1000)
 
-    def _convert_to_exif_format(
-        self, degrees: int, minutes: int, seconds: float
-    ) -> Tuple[Tuple[int, int], Tuple[int, int], Tuple[Union[int, float], int]]:
+    def _convert_coord_to_exif_format(
+        self, gps_coord: int, is_latitude: bool
+    ) -> Tuple[Tuple[Tuple[int, int], Tuple[int, int], Tuple[int, int]], str]:
         """
-        Converts degrees, minutes, seconds to EXIF format
+        Converts latitude or longitude in 1e-7 degrees format to EXIF format.
         """
-        return ((degrees * 1, 1), (minutes * 1, 1), (seconds * 100, 100))
+        decimal_degrees = gps_coord / 1e7
+
+        # Extract degrees, minutes, and seconds
+        degrees = int(decimal_degrees)
+        minutes_decimal = (decimal_degrees - degrees) * 60
+        minutes = int(minutes_decimal)
+        seconds = (minutes_decimal - minutes) * 60
+
+        # Format for EXIF GPS format
+        exif_coord = (
+            (degrees, 1),
+            (minutes, 1),
+            (int(seconds * 10000), 10000),  # Use 4 decimal places for seconds
+        )
+
+        if is_latitude:
+            exif_ref = "N" if decimal_degrees >= 0 else "S"
+        else:
+            exif_ref = "E" if decimal_degrees >= 0 else "W"
+
+        return exif_coord, exif_ref
 
     def _get_exif_gps_data(self) -> dict:
+        lat, lat_ref = self._convert_coord_to_exif_format(
+            self.gps_data.lat, is_latitude=True
+        )
+        lon, lon_ref = self._convert_coord_to_exif_format(
+            self.gps_data.lon, is_latitude=False
+        )
+
+        # Convert to datetime
+        _gps_timestamp = datetime.fromtimestamp(
+            self.gps_data.time_usec / 1e6, tz=timezone.utc
+        )
+
         return {
-            piexif.GPSIFD.GPSLatitude: self._convert_to_exif_format(
-                self.gps_data.GPSLatitude
+            piexif.GPSIFD.GPSLatitude: lat,
+            piexif.GPSIFD.GPSLatitudeRef: lat_ref.encode(),
+            piexif.GPSIFD.GPSLongitude: lon,
+            piexif.GPSIFD.GPSLongitudeRef: lon_ref.encode(),
+            piexif.GPSIFD.GPSAltitude: (int(self.gps_data.alt * 1000), 1000),
+            piexif.GPSIFD.GPSAltitudeRef: 0,  # above mean sea level
+            piexif.GPSIFD.GPSDateStamp: _gps_timestamp.strftime("%Y:%m:%d").encode(),
+            piexif.GPSIFD.GPSTimeStamp: (
+                (_gps_timestamp.hour, 1),
+                (_gps_timestamp.minute, 1),
+                (_gps_timestamp.second, 1),
             ),
-            piexif.GPSIFD.GPSLatitudeRef: self.gps_data.GPSLatitudeRef.encode(),
-            piexif.GPSIFD.GPSLongitude: self._convert_to_exif_format(
-                self.gps_data.GPSLongitude
-            ),
-            piexif.GPSIFD.GPSLongitudeRef: self.gps_data.GPSLongitudeRef.encode(),
-            piexif.GPSIFD.GPSAltitude: self.gps_data.GPSAltitude,
-            piexif.GPSIFD.GPSAltitudeRef: self.gps_data.GPSAltitudeRef,
-            piexif.GPSIFD.GPSDateStamp: self.gps_data.GPSDateStamp.encode(),
-            piexif.GPSIFD.GPSTimeStamp: self.gps_data.GPSTimeStamp,
+        }
+
+    def _get_exif_misc_data(self) -> dict:
+        return {
+            piexif.ImageIFD.Model: self.misc_data.camera_model.encode(),
+            piexif.ExifIFD.FocalLength: self.misc_data.focal_length,
+            piexif.ExifIFD.DateTimeOriginal: self.current_datetime.encode(),
+            piexif.ExifIFD.SubSecTimeOriginal: str(self.current_datetime_ms).encode(),
         }
 
     def _get_exif_bytes(self) -> bytes:
         """
         Returns the bytes of the EXIF formatted GPS formatted data
         """
-        exif_dict = {"GPS": self._get_exif_gps_data()}
+        exif_dict = {
+            "GPS": self._get_exif_gps_data(),
+            "Exif": self._get_exif_misc_data(),
+        }
         return piexif.dump(exif_dict)
 
-    def add_exif_metadata(self) -> None:
-        if not self.gps_data:
-            print("No GPS data to add")
+    def _add_xmp_data(self) -> None:
+        """
+        Adds XMP metadata for yaw, pitch, and roll since this is not supported by EXIF
+        but still common for photogrammetry software.
+        """
+        metadata = pyexiv2.ImageMetadata(self.file_name)
+        metadata.read()
+
+        # Set XMP tags for misc GPS/camera data
+        metadata["Xmp.Camera.Yaw"] = (
+            self.gps_data.cog / 100.0
+        )  # Course over ground comes from GPS as centidegrees
+        metadata["Xmp.Camera.Pitch"] = self.misc_data.pitch
+        metadata["Xmp.Camera.Roll"] = self.misc_data.roll
+        metadata["Xmp.Camera.GPSFixType"] = self.gps_data.fix_type
+        metadata["Xmp.Camera.SatellitesVisible"] = self.gps_data.satellites_visible
+        metadata["Xmp.Camera.GPSHDOP"] = self.gps_data.eph / 100.0  # Convert cm to m
+        metadata["Xmp.Camera.GPSVDOP"] = self.gps_data.epv / 100.0  # Convert cm to m
+        metadata["Xmp.Camera.GroundSpeed"] = (
+            self.gps_data.vel / 100.0
+        )  # Convert cm/s to m/s
+
+        metadata.write()  # Write XMP data to the image
+
+    def add_metadata(self) -> None:
+        if not self.gps_data and not self.misc_data:
+            print("No GPS and Camera data to add")
             return
         image = Image.open(self.file_name)
         image.save(self.file_name, exif=self._get_exif_bytes())
+
+        # Add XMP metadata for pitch, roll etc.
+        self._add_xmp_data()

--- a/exif_service.py
+++ b/exif_service.py
@@ -1,0 +1,48 @@
+from typing import Tuple, Union
+from constants import ExifDataGPS
+import piexif
+from PIL import Image
+
+
+class EXIFService:
+    def __init__(self, gps_data: ExifDataGPS, file_name: str):
+        self.gps_data = gps_data
+        self.file_name = file_name
+
+    def _convert_to_exif_format(
+        self, degrees: int, minutes: int, seconds: float
+    ) -> Tuple[Tuple[int, int], Tuple[int, int], Tuple[Union[int, float], int]]:
+        """
+        Converts degrees, minutes, seconds to EXIF format
+        """
+        return ((degrees * 1, 1), (minutes * 1, 1), (seconds * 100, 100))
+
+    def _get_exif_gps_data(self) -> dict:
+        return {
+            piexif.GPSIFD.GPSLatitude: self._convert_to_exif_format(
+                self.gps_data.GPSLatitude
+            ),
+            piexif.GPSIFD.GPSLatitudeRef: self.gps_data.GPSLatitudeRef.encode(),
+            piexif.GPSIFD.GPSLongitude: self._convert_to_exif_format(
+                self.gps_data.GPSLongitude
+            ),
+            piexif.GPSIFD.GPSLongitudeRef: self.gps_data.GPSLongitudeRef.encode(),
+            piexif.GPSIFD.GPSAltitude: self.gps_data.GPSAltitude,
+            piexif.GPSIFD.GPSAltitudeRef: self.gps_data.GPSAltitudeRef,
+            piexif.GPSIFD.GPSDateStamp: self.gps_data.GPSDateStamp.encode(),
+            piexif.GPSIFD.GPSTimeStamp: self.gps_data.GPSTimeStamp,
+        }
+
+    def _get_exif_bytes(self) -> bytes:
+        """
+        Returns the bytes of the EXIF formatted GPS formatted data
+        """
+        exif_dict = {"GPS": self._get_exif_gps_data()}
+        return piexif.dump(exif_dict)
+
+    def add_exif_metadata(self) -> None:
+        if not self.gps_data:
+            print("No GPS data to add")
+            return
+        image = Image.open(self.file_name)
+        image.save(self.file_name, exif=self._get_exif_bytes())

--- a/exif_service.py
+++ b/exif_service.py
@@ -99,8 +99,6 @@ class EXIFService:
         """
 
         metadata = pyexiv2.ImageMetadata(self.file_name)
-        # import pdb
-        # pdb.set_trace()
         metadata.read()
 
         # Set XMP tags for misc GPS/camera data

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,3 +6,11 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-libcamera]
 ignore_missing_imports = True
+[mypy-zmq]
+ignore_missing_imports = True
+[mypy-piexif]
+ignore_missing_imports = True
+[mypy-PIL]
+ignore_missing_imports = True
+[mypy-pyexiv2]
+ignore_missing_imports = True

--- a/pistreamer_v2.py
+++ b/pistreamer_v2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from typing import Any, Optional
+from exif_service import EXIFService
 from ffmpeg_configs import (
     get_ffmpeg_command_mpeg_ts,
     get_ffmpeg_command_record,
@@ -75,6 +76,8 @@ class PiStreamer2:
         self.original_size = (0, 0)
         self.recording_start_time = 0
         self.max_zoom = max_zoom
+        # video metadata
+        self.gps_data = {}
         # stabilize settings
         self.stabilize = stabilize
         self.prev_gray = None
@@ -307,6 +310,9 @@ class PiStreamer2:
             self.picam2.configure(self.streaming_config)
             self.command_controller.set_zoom(_original_zoom)
             self.picam2.start()
+
+        # Lastly update the photo with the exif data
+        EXIFService(self.gps_data, file_name).add_exif_metadata()
 
     def _format_duration(self, seconds: int) -> str:
         """Convert a duration in seconds to a minutes:seconds format."""

--- a/pistreamer_v2.py
+++ b/pistreamer_v2.py
@@ -10,6 +10,7 @@ from ffmpeg_configs import (
 import os
 from pathlib import Path
 from picamera2 import Picamera2
+import pyexiv2
 import cv2
 import numpy as np
 import time
@@ -24,6 +25,8 @@ from constants import (
     INIT_BBOX_COLOR,
     MEDIA_FILES_DIRECTORY,
     MIN_ZOOM,
+    NAMESPACE_PREFIX,
+    NAMESPACE_URI,
     STREAMING_FRAMESIZE,
     STILL_FRAMESIZE,
     CommandProtocolType,
@@ -81,6 +84,9 @@ class PiStreamer2:
         # video metadata
         self.gps_data = MavlinkGPSData()
         self.misc_data = MavlinkMiscData()
+        pyexiv2.xmp.register_namespace(
+            NAMESPACE_URI, NAMESPACE_PREFIX
+        )  # Register the custom namespace for XMP
         # stabilize settings
         self.stabilize = stabilize
         self.prev_gray = None

--- a/pistreamer_v2.py
+++ b/pistreamer_v2.py
@@ -27,6 +27,8 @@ from constants import (
     STREAMING_FRAMESIZE,
     STILL_FRAMESIZE,
     CommandProtocolType,
+    MavlinkGPSData,
+    MavlinkMiscData,
     StreamingProtocolType,
     TrackStatus,
     ZoomStatus,
@@ -77,7 +79,8 @@ class PiStreamer2:
         self.recording_start_time = 0
         self.max_zoom = max_zoom
         # video metadata
-        self.gps_data = {}
+        self.gps_data = MavlinkGPSData()
+        self.misc_data = MavlinkMiscData()
         # stabilize settings
         self.stabilize = stabilize
         self.prev_gray = None
@@ -312,7 +315,7 @@ class PiStreamer2:
             self.picam2.start()
 
         # Lastly update the photo with the exif data
-        EXIFService(self.gps_data, file_name).add_exif_metadata()
+        EXIFService(self.gps_data, self.misc_data, file_name).add_metadata()
 
     def _format_duration(self, seconds: int) -> str:
         """Convert a duration in seconds to a minutes:seconds format."""

--- a/pistreamer_v2.py
+++ b/pistreamer_v2.py
@@ -365,7 +365,8 @@ class PiStreamer2:
     def _read_and_process_commands(self) -> None:
         commands = self.command_service.get_pending_commands()
         for command in commands:
-            print(f"Processing command `{command}`")
+            if self.verbose:
+                print(f"Processing command `{command}`")
             try:
                 self.command_controller.handle_command(
                     command_type=command[0], command_value=command[1]

--- a/socket_service.py
+++ b/socket_service.py
@@ -73,10 +73,10 @@ class SocketService(CommandService):
         try:
             _data = data.strip().encode()
             client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            client_socket.connect((OUTPUT_SOCKET_HOST, OUTPUT_SOCKET_PORT))
+            client_socket.connect((CMD_SOCKET_HOST, OUTPUT_SOCKET_PORT))
             client_socket.sendall(_data)
         except Exception as e:
-            print(f"{OUTPUT_SOCKET_HOST}:{OUTPUT_SOCKET_PORT} {e}")
+            print(f"{CMD_SOCKET_HOST}:{OUTPUT_SOCKET_PORT} {e}")
         finally:
             client_socket.close()
 

--- a/socket_service.py
+++ b/socket_service.py
@@ -73,10 +73,10 @@ class SocketService(CommandService):
         try:
             _data = data.strip().encode()
             client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            client_socket.connect((CMD_SOCKET_HOST, OUTPUT_SOCKET_PORT))
+            client_socket.connect((OUTPUT_SOCKET_HOST, OUTPUT_SOCKET_PORT))
             client_socket.sendall(_data)
         except Exception as e:
-            print(f"{CMD_SOCKET_HOST}:{OUTPUT_SOCKET_PORT} {e}")
+            print(f"{OUTPUT_SOCKET_HOST}:{OUTPUT_SOCKET_PORT} {e}")
         finally:
             client_socket.close()
 


### PR DESCRIPTION
This PR adds the ability to tag jpeg photos with EXIF and XMP info about GPS, camera, and attitude. This can allow photos to be used for photogrammetry solutions. 

### Sample data commands for updating pistreamer's copy of metadata
* `gps_data '{"lat": 359686990, "lon": -839290440, "alt": 276, "eph": 1, "epv": 1, "vel": 0, "cog": 0, "fix_type": 2, "satellites_visible": 10, "time_usec": 1730920262680000}'`
* `misc_data '{"pitch": 0.1, "roll": 0.02, "camera_model": "IMX477", "focal_length": [50, 1]}'`

### Sample EXIF data of a captured image:
![image](https://github.com/user-attachments/assets/f062f86c-1138-48a2-ac8d-a6ea91387e28)

